### PR TITLE
Wrong error message showing when a bill can't be found

### DIFF
--- a/src/com/sunlightlabs/congress/services/BillService.java
+++ b/src/com/sunlightlabs/congress/services/BillService.java
@@ -199,7 +199,7 @@ public class BillService {
 		try {
 			JSONArray results = new JSONObject(rawJSON).getJSONArray("bills");
 			if (results.length() == 0)
-				throw new CongressException("Bill not found.");
+				throw new CongressException.NotFound("Bill not found.");
 			else
 				return fromRTC(results.getJSONObject(0));
 		} catch (JSONException e) {


### PR DESCRIPTION
When a bill is not found (for example, just type in HR999999), the API doesn't give a status of 404, but instead a 200 with a zero-length array. In this case `BillService` just throws a `CongressException` instead of a `CongressException.NotFound`. This results in the user seeing an incorrect error message.
