### PR TITLE
Remove support for other distribution/market channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Congress for Android
 
-This is the source code for the Sunlight Foundation's [Congress app](http://congress.sunlightfoundation.com) for Android phones.
+This is the source code for the Eric Mill's Congress app for Android phones. (This app was previously funded and developed for years by the [Sunlight Foundation](https://sunlightfoundation.com).)
 
 Find the most up-to-date version in the Google Play Store: https://play.google.com/store/apps/details?id=com.sunlightlabs.android.congress
 
 We ship the app using the code found in this repository, with some miscellaneous unversioned API keys and build information placed in `app/src/main/res/values/keys.xml`.
 
-We use [Github Issues](/sunlightlabs/congress-android/issues) for issue tracking.
+We use [Github Issues](https:/github.com/konklone/congress-android/issues) for issue tracking.
 
 ### Setup
 
@@ -50,21 +50,14 @@ Code changes:
 Then, release work:
 
 * **Temporarily** add `android:debuggable="false"` in the `<application>` tag in `AndroidManifest.xml`.
-    * manually specifying is (unfortunately) [required](http://stackoverflow.com/questions/20051192/unable-to-upload-updated-apk-to-google-play-store) when working in Android Studio, as it will otherwise default to being debuggable.
+    * manually specifying is (unfortunately) [required](https://stackoverflow.com/questions/20051192/unable-to-upload-updated-apk-to-google-play-store) when working in Android Studio, as it will otherwise default to being debuggable.
 * Check keys.xml:
-  - is api_endpoint pointing to production? https?
-  - is the distribution_channel correct? (market vs ____)
-  - is the market_channel correct? (google vs amazon)
+  - is api_endpoint pointing to production?
   - are all debug flags set to false?
 * Produce unsigned APK version
 * Produce signed APK version
-  - if desired, produce separate APK version for Amazon
 * Then **remove** `android:debuggable` from the `<application>` tag in `AndroidManifest.xml`.
 * Take any screenshots needed to replace outdated ones
-  - Replace any new screenshots in Dropbox
-* Store APKs in Dropbox
+  - Replace any new screenshots in _____ (GitHub?)
+* Store APKs in ____ (GitHub?)
 
-Finally, publish:
-
-* Google Play market
-* Amazon Appstore market

--- a/app/src/main/java/com/sunlightlabs/android/congress/MenuMain.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/MenuMain.java
@@ -36,7 +36,6 @@ public class MenuMain extends Activity implements ActionBarUtils.HasActionMenu {
 		
 		if (firstTime()) {
 			newVersion(); // don't need to see the changelog on first install
-			storeOriginalChannel();
 			FragmentUtils.alertDialog(this, AlertFragment.FIRST);
 			setNotificationState(); // initially, all notifications are stopped
 		} else if (newVersion()) {
@@ -103,15 +102,7 @@ public class MenuMain extends Activity implements ActionBarUtils.HasActionMenu {
 		}
 		return false;
 	}
-	
-	// store the value that was originally in keys.xml as the distribution channel
-	// this is essentially to track non-Market original installs, even if the user 
-	// eventually updates to a version of the app from the Market.
-	public void storeOriginalChannel() {
-		String channel = getResources().getString(R.string.distribution_channel);
-		Utils.setStringPreference(this, Analytics.DIMENSION_ORIGINAL_CHANNEL_PREFERENCE, channel);
-	}
-	
+
 	// used for one-pager
 	// change name of preference variable for a new one-pager
 	 public boolean shownOnePager() {
@@ -157,16 +148,11 @@ public class MenuMain extends Activity implements ActionBarUtils.HasActionMenu {
 	
 	public void goReview() {
 		String packageName = getResources().getString(R.string.app_package_name);
-		String channel = getResources().getString(R.string.market_channel);
-		
-		Analytics.reviewClick(this, channel);
+
+		Analytics.reviewClick(this);
 		
 		try {
-			String uri;
-			if (channel.equals("amazon"))
-				uri = "http://www.amazon.com/gp/mas/dl/android?p=" + packageName;
-			else
-				uri = "market://details?id=" + packageName;
+			String uri = "market://details?id=" + packageName;
 			
 			startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(uri)));
 		} catch(ActivityNotFoundException e) {

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Analytics.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Analytics.java
@@ -93,11 +93,6 @@ public class Analytics {
 	 *  Custom dimensions and metrics.
 	 */
 	
-	public static final int DIMENSION_MARKET_CHANNEL = 1; // market channel (user)
-	
-	public static final int DIMENSION_ORIGINAL_CHANNEL = 2; // original distribution channel (user)
-	public static final String DIMENSION_ORIGINAL_CHANNEL_PREFERENCE = "original_distribution_channel";
-	
 	public static final int DIMENSION_NOTIFICATIONS_ON = 3; // whether notifications are enabled (session)
 	
 	public static final int DIMENSION_ENTRY = 4; // how the user entered the app (hit)
@@ -105,22 +100,12 @@ public class Analytics {
 	public static HitBuilders.EventBuilder attachCustomDimensions(Activity activity, HitBuilders.EventBuilder event) {
 		Resources res = activity.getResources();
 
-		String marketChannel = res.getString(R.string.market_channel);
-		event = event.setCustomDimension(DIMENSION_MARKET_CHANNEL, marketChannel);
-
-		String originalChannel = Utils.getStringPreference(activity, DIMENSION_ORIGINAL_CHANNEL_PREFERENCE);
-        event = event.setCustomDimension(DIMENSION_ORIGINAL_CHANNEL, originalChannel);
-
 		boolean notificationsOn = Utils.getBooleanPreference(activity, NotificationSettings.KEY_NOTIFY_ENABLED, false);
         event = event.setCustomDimension(DIMENSION_NOTIFICATIONS_ON, notificationsOn ? "on" : "off");
 
 		String entrySource = entrySource(activity);
 		if (entrySource != null)
             event = event.setCustomDimension(DIMENSION_ENTRY, entrySource);
-
-		// debug: output custom dimensions
-//		String msg = "[" + marketChannel + "][" + originalChannel + "][" + (notificationsOn ? "on" : "off") + "][" + (entrySource != null ? entrySource : "nothing") + "]";
-//		Log.i(Utils.TAG, msg);
 
         return event;
 	}
@@ -220,10 +205,10 @@ public class Analytics {
 		event(activity, EVENT_CHANGELOG, CHANGELOG_VALUE, null);
 	}
 	
-	public static void reviewClick(Activity activity, String market) {
-		event(activity, EVENT_REVIEW, market, null);
+	public static void reviewClick(Activity activity) {
+		event(activity, EVENT_REVIEW, null, null);
 	}
-	
+
 	public static void addFavoriteLegislator(Activity activity, String bioguideId) {
 		event(activity, EVENT_FAVORITE, FAVORITE_ADD_LEGISLATOR, bioguideId);
 	}

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
@@ -39,7 +39,6 @@ public class Utils {
 		Congress.userAgent = resources.getString(R.string.api_user_agent);
 		Congress.apiKey = resources.getString(R.string.sunlight_api_key);
 		Congress.appVersion = resources.getString(R.string.app_version);
-		Congress.appChannel = resources.getString(R.string.market_channel);
 		
 		Congress.osVersion = "Android " + Build.VERSION.SDK_INT;
 	}

--- a/app/src/main/java/com/sunlightlabs/congress/services/Congress.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/Congress.java
@@ -45,7 +45,6 @@ public class Congress {
 	public static String baseUrl = null;
 	public static String userAgent = null;
 	public static String appVersion = null;
-	public static String appChannel = null;
 	public static String apiKey = null;
 
 	// filled in by the client from Android system reflection
@@ -203,15 +202,12 @@ public class Congress {
 	        if (appVersion != null)
 	        	connection.setRequestProperty("x-app-version", appVersion);
 
-	        if (appChannel != null)
-	        	connection.setRequestProperty("x-app-channel", appChannel);
-
 	        int status = connection.getResponseCode();
 	        if (status == HttpURLConnection.HTTP_OK) {
 	        	// read input stream first to fetch response headers
 	        	InputStream in = connection.getInputStream();
 
-	        	// adapted from http://stackoverflow.com/a/2549222/16075
+	        	// adapted from https://stackoverflow.com/a/2549222/16075
 	        	BufferedReader reader = new BufferedReader(new InputStreamReader(in));
 	        	StringBuilder total = new StringBuilder();
 	        	String line;

--- a/keys.xml.example
+++ b/keys.xml.example
@@ -3,14 +3,10 @@
     <string name="contact_email"></string>
     <string name="contact_subject"></string>
 
-	<string name="mapbox_id"></string>
-
+   <string name="propublica_api_key">CHANGEME</string>
     <string name="sunlight_api_key">CHANGEME</string>
     <string name="api_user_agent">CHANGEME</string>
     <string name="api_endpoint">https://congress.api.sunlightfoundation.com</string>
-
-    <!-- usually "market", can be changed for non-market distributions -->
-    <string name="distribution_channel"></string>
 
     <!-- must be either "google" or "amazon" -->
     <string name="market_channel"></string>

--- a/keys.xml.example
+++ b/keys.xml.example
@@ -8,9 +8,6 @@
     <string name="api_user_agent">CHANGEME</string>
     <string name="api_endpoint">https://congress.api.sunlightfoundation.com</string>
 
-    <!-- must be either "google" or "amazon" -->
-    <string name="market_channel"></string>
-
     <string name="debug_disable_analytics">false</string>
     <string name="debug_show_buttons">false</string>
     <string name="debug_always_notify">false</string>


### PR DESCRIPTION
We're no longer distributing this APK directly as a pre-install, or through the Amazon Appstore. Removes all code/docs/etc that support additional channels.

Also updates the README to make it a bit more accurate.

Fixes #654.