### PR TITLE
Migrate legislator lookups and state listings to the Pro Publica Congress API

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
@@ -271,7 +271,7 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 	}
 
 	public void selectLegislator(Legislator legislator) {
-		startActivity(Utils.legislatorIntent(getActivity(), legislator));
+		startActivity(Utils.legislatorIntent(legislator.bioguide_id));
 	}
 	
 	private static class LegislatorAdapter extends ArrayAdapter<Legislator> {
@@ -407,7 +407,7 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 					temp = CommitteeService.find(context.committee.id).members;
 					break;
 				case SEARCH_STATE:
-					temp = LegislatorService.allWhere("state", context.state);
+					temp = LegislatorService.allForState(context.state);
 					break;
 				case SEARCH_COSPONSORS:
 					temp = BillService.find(context.billId, new String[] {"cosponsors"}).cosponsors;

--- a/app/src/main/java/com/sunlightlabs/android/congress/tasks/LoadLegislatorTask.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/tasks/LoadLegislatorTask.java
@@ -36,11 +36,11 @@ public class LoadLegislatorTask extends AsyncTask<String, Void, Legislator> {
 		try {
 			Legislator legislator = LegislatorService.find(params[0]);
 			if (legislator == null)
-				this.exception = new CongressException("Can't load legislator with this ID from Sunlight.");
+				this.exception = new CongressException("Can't find/load legislator with ID: " + params[0]);
 			
 			return legislator;
 		} catch (CongressException exception) {
-			Log.w(Utils.TAG, "Could not load the legislator with id " + params[0] + " from Sunlight");
+			Log.w(Utils.TAG, "Error loading the legislator with ID: " + params[0]);
 			this.exception = exception;
 			return null;
 		}

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Database.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Database.java
@@ -19,20 +19,30 @@ import java.util.Date;
 import java.util.List;
 
 public class Database {
-	private static final int DATABASE_VERSION = 9; // updated last for version 4.6
+	// updated last for version 4.6
+	private static final int DATABASE_VERSION = 9;
 
 	public boolean closed = true;
 
 	private static final String DATABASE_NAME = "congress.db";
 
-	private static final String[] LEGISLATOR_COLUMNS = new String[] { "bioguide_id",
-			"first_name", "last_name", "nickname", "name_suffix", "title", "party",
-			"state", "district", "gender" };
-	private static final String[] BILL_COLUMNS = new String[] { "id", "short_title", "official_title" };
+	// TODO: remove/migrate out name_suffix, nickname fields
+	private static final String[] LEGISLATOR_COLUMNS = new String[] {
+		"bioguide_id", "first_name", "last_name", "nickname",
+		"name_suffix", "title", "party", "state", "district", "gender"
+	};
 
-	private static final String[] SUBSCRIPTION_COLUMNS = new String[] { "id", "name", "data", "notification_class", "unseen_count" };
+	private static final String[] BILL_COLUMNS = new String[] {
+		"id", "short_title", "official_title"
+	};
+
+	private static final String[] SUBSCRIPTION_COLUMNS = new String[] {
+		"id", "name", "data", "notification_class", "unseen_count"
+	};
 	
-	private static final String[] SEEN_COLUMNS = new String[] { "subscription_id", "subscription_class", "seen_id" };
+	private static final String[] SEEN_COLUMNS = new String[] {
+		"subscription_id", "subscription_class", "seen_id"
+	};
 
 	private DatabaseHelper helper;
 	private SQLiteDatabase database;

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
@@ -21,6 +21,7 @@ import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 import com.sunlightlabs.congress.models.Roll;
 import com.sunlightlabs.congress.services.Congress;
+import com.sunlightlabs.congress.services.ProPublica;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -39,9 +40,12 @@ public class Utils {
 		Congress.userAgent = resources.getString(R.string.api_user_agent);
 		Congress.apiKey = resources.getString(R.string.sunlight_api_key);
 		Congress.appVersion = resources.getString(R.string.app_version);
-		
 		Congress.osVersion = "Android " + Build.VERSION.SDK_INT;
-	}
+
+		ProPublica.baseUrl = resources.getString(R.string.propublica_api_endpoint);
+        ProPublica.userAgent = resources.getString(R.string.api_user_agent);
+        ProPublica.apiKey = resources.getString(R.string.propublica_api_key);
+    }
 
 	public static void alert(Context context, String msg) {
 		Toast.makeText(context, msg, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -40,6 +40,23 @@ public class Legislator implements Comparable<Legislator>, Serializable {
 		return last_name + ", " + firstName();
 	}
 
+	public static String[] splitName(String displayName) {
+		String[] pieces = displayName.split(" ");
+		String first_name = pieces[0];
+		String last_name = pieces[pieces.length-1];
+
+		if (
+			last_name.equals("Jr.") ||
+			last_name.equals("II") ||
+			last_name.equals("III")
+		)
+			last_name = pieces[pieces.length-2] + " " + pieces[pieces.length-1];
+
+
+		String[] names = {first_name, last_name};
+		return names;
+	}
+
 	// Used to parse long titles from Pro Publica API
 	// TODO: store long title natively and abbreviate at render-time
 	public static String shortTitle(String longTitle) {

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -40,6 +40,20 @@ public class Legislator implements Comparable<Legislator>, Serializable {
 		return last_name + ", " + firstName();
 	}
 
+	// Used to parse long titles from Pro Publica API
+	// TODO: store long title natively and abbreviate at render-time
+	public static String shortTitle(String longTitle) {
+		if (longTitle.equals("Representative"))
+			return "Rep";
+		// Can be "Senator, 3rd Class"
+		else if (longTitle.startsWith("Senator"))
+			return "Sen";
+		else if (longTitle.equals("Delegate"))
+			return "Del";
+		else if (longTitle.equals("Resident Commissioner"));
+			return "Com";
+	}
+
 	public String fullTitle() {
 		String title = this.title;
 		if (title.equals("Del"))

--- a/app/src/main/java/com/sunlightlabs/congress/services/Congress.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/Congress.java
@@ -114,7 +114,7 @@ public class Congress {
 					query.append("&");
 			}
 		} catch(UnsupportedEncodingException e) {
-			throw new CongressException(e, "Unicode not supported on this phone somehow.");
+			throw new CongressException(e, "Unicode not supported on this device somehow.");
 		}
 
 		return baseUrl + "/" + method + "?" + query.toString();

--- a/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
@@ -1,0 +1,173 @@
+package com.sunlightlabs.congress.services;
+
+
+import android.util.Log;
+
+import com.sunlightlabs.android.congress.utils.HttpManager;
+import com.sunlightlabs.android.congress.utils.Utils;
+import com.sunlightlabs.congress.models.CongressException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class ProPublica {
+
+    // Pro Publica Per Page
+    public static int PPPP = 20;
+
+    // filled in by the client in keys.xml
+    public static String baseUrl = null;
+    public static String userAgent = null;
+    public static String apiKey = null;
+
+    public static String url(String[] components) throws CongressException {
+        return url(components, -1);
+    }
+
+    public static String url(String[] components, int page) throws CongressException {
+        if (components == null || components.length == 0)
+            throw new CongressException("No path components given.");
+
+        // cobble together the path components
+        StringBuilder path = new StringBuilder("");
+
+        try {
+            for (int i=0; i < components.length; i++) {
+                path.append(URLEncoder.encode(components[i], "UTF-8"));
+                if ((i + 1) < components.length)
+                    path.append("/");
+            }
+        } catch(UnsupportedEncodingException e) {
+            throw new CongressException(e, "Unicode not supported on this device somehow.");
+        }
+        path.append(".json");
+
+
+        // cobble together any needed query string params
+        Map<String,String> params = new HashMap<String,String>();
+
+        // Only use for query string is an "offset" for pagination as needed
+        if (page > 0) {
+            int offset = (page - 1) * PPPP;
+            params.put("offset", String.valueOf(offset));
+        }
+
+        StringBuilder query = new StringBuilder("");
+        Iterator<String> iterator = params.keySet().iterator();
+        if (iterator.hasNext()) {
+            query.append("?");
+            try {
+                while (iterator.hasNext()) {
+                    String key = iterator.next();
+                    String value = params.get(key);
+
+                    query.append(URLEncoder.encode(key, "UTF-8"));
+                    query.append("=");
+                    query.append(URLEncoder.encode(value, "UTF-8"));
+                    if (iterator.hasNext())
+                        query.append("&");
+                }
+            } catch (UnsupportedEncodingException e) {
+                throw new CongressException(e, "Unicode not supported on this device somehow.");
+            }
+        }
+
+        return baseUrl + path.toString() + query.toString();
+    }
+
+    public static String fetchJSON(String url) throws CongressException {
+        Log.d(Utils.TAG, "Pro Publica API: " + url);
+
+        // play nice with OkHttp
+        HttpManager.init();
+
+        HttpURLConnection connection;
+        URL theUrl;
+
+        try {
+            theUrl = new URL(url);
+            connection = (HttpURLConnection) theUrl.openConnection();
+        } catch(MalformedURLException e) {
+            throw new CongressException(e, "Bad URL: " + url);
+        } catch (IOException e) {
+            throw new CongressException(e, "Problem opening connection to " + url);
+        }
+
+        try {
+            // Identify ourselves as the Congress app
+            connection.setRequestProperty("User-Agent", userAgent);
+
+            // Supply the Pro Publica API key over a header
+            connection.setRequestProperty("X-API-Key", apiKey);
+
+            int status = connection.getResponseCode();
+            if (status == HttpURLConnection.HTTP_OK) {
+                // read input stream first to fetch response headers
+                InputStream in = connection.getInputStream();
+
+                // adapted from https://stackoverflow.com/a/2549222/16075
+                BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+                StringBuilder total = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) total.append(line);
+
+                return total.toString();
+
+            } else if (status == HttpURLConnection.HTTP_NOT_FOUND)
+                throw new CongressException.NotFound("404 Not Found from " + url);
+            else
+                throw new CongressException("Bad status code " + status+ " on fetching JSON from " + url);
+
+        } catch (IOException e) {
+            throw new CongressException(e, "Problem fetching JSON from " + url);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    public static JSONObject firstResult(String url) throws CongressException {
+        JSONArray results = resultsFor(url);
+        if (results.length() > 0) {
+            try {
+                return (JSONObject) results.get(0);
+            } catch(JSONException e) {
+                throw new CongressException(e, "Error getting first result from " + url);
+            }
+        } else
+            return null;
+    }
+
+    public static JSONArray resultsFor(String url) throws CongressException {
+        String rawJSON = fetchJSON(url);
+        JSONArray results = null;
+        try {
+            JSONObject response = new JSONObject(rawJSON);
+
+            // First check that the Pro Publica API said 'OK'
+            String status = response.getString("status");
+            if (!status.equals("OK"))
+                throw new CongressException("Got a non-OK status from " + url + "\n\n" + rawJSON);
+
+            results = response.getJSONArray("results");
+
+        } catch(JSONException e) {
+            throw new CongressException(e, "Problem parsing the JSON from " + url);
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
This is the first real integration with the Pro Publica Congress API. It's not complete, but I wanted to get a couple endpoints done. I intend to ship this out to users so that we can start getting real world feedback from both users and from Pro Publica.

We now have two screens use the Pro Publica API:

* The legislator "home screen", which shows the legislator's main information and photo. The other two "tabs" on that screen, for the legislator's votes and bills, are untouched and use the Congress API.

* Showing legislators "by state". This listing comes up when you go to `Legislators`, and then pick the `State` tab, and then pick one of the 56 states/districts. 

Pro Publica has kindly extended the API rate limit for my key up to 10K requests per day. Neither of the above two screens are tied to push notifications, so they shouldn't get polled automatically by the app. Every API request will be initiated by an individual user.

Some notes:

* To assemble a list of all senators and representatives by state, we now make 2 API requests instead of one, as the [State/District endpoint](https://projects.propublica.org/api-docs/congress-api/endpoints/#get-current-members-by-statedistrict) is scoped per-chamber.
* We now consistently reload the legislator's information from the API every time we visit their home screen. Previously, we were able to reuse information from the listing endpoint and feed it directly into the home screen, so that a new API request wasn't necessary to re-download that information for a specific member. However, the dearth of fields on the [State/District endpoint](https://projects.propublica.org/api-docs/congress-api/endpoints/#get-current-members-by-statedistrict) makes that challenging for this application.
* The [State/District endpoint](https://projects.propublica.org/api-docs/congress-api/endpoints/#get-current-members-by-statedistrict) uses a `name` field without individual names, but we want to sort by last name and use our typical name display algorithm. So I'm doing some crude string splitting on names, which could result in inconsistent name display, in some edge cases, on the listing than on the home screen for a meber.
* I filed a [bunch of issues on the PP API issue tracker](https://github.com/propublica/congress-api-docs/issues?utf8=%E2%9C%93&q=author%3Akonklone) that track small bugs and some refactoring suggestions I made after implementing as a client. Some of these were small things, like using `null` or boolean values instead of strings, and some were larger, like suggesting potentially breaking field renames or data hierarchy changes.