### PR TITLE
Remove OC menu link, fix GovTrack URL

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/LegislatorPager.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/LegislatorPager.java
@@ -179,9 +179,6 @@ public class LegislatorPager extends Activity implements HasActionMenu {
             case R.id.govtrack:
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Legislator.govTrackUrl(legislator.govtrack_id))));
     		break;
-            case R.id.opencongress:
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Legislator.openCongressUrl(legislator.govtrack_id))));
-    		break;
             case R.id.bioguide:
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Legislator.bioguideUrl(legislator.bioguide_id))));
     		break;

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -123,16 +123,8 @@ public class Legislator implements Comparable<Legislator>, Serializable {
 		return "http://bioguide.congress.gov/scripts/biodisplay.pl?index=" + bioguide_id;
 	}
 	
-	public static String openCongressUrl(String govtrack_id) {
-		return "http://www.opencongress.org/person/show/" + govtrack_id;
-	}
-	
 	public static String govTrackUrl(String govtrack_id) {
-		return "http://www.govtrack.us/congress/person.xpd?id=" + govtrack_id;
-	}
-	
-	public static String sunlightShortUrl(String bioguide_id) {
-		return "http://cngr.es/l/" + bioguide_id;
+        return "https://www.govtrack.us/congress/members/anything/" + govtrack_id;
 	}
 	
 	public String toString() {

--- a/app/src/main/res/menu/legislator.xml
+++ b/app/src/main/res/menu/legislator.xml
@@ -15,9 +15,4 @@
 		android:alphabeticShortcut="g"
 		android:icon="@drawable/govtrack"
 		/>
-	<item android:id="@+id/opencongress"
-		android:title="More at OpenCongress"
-		android:alphabeticShortcut="o"
-		android:icon="@drawable/opencongress"
-		/>
 </menu>


### PR DESCRIPTION
This removes the OC menu option, and fixes the GovTrack URL to use their new URL schema and to use HTTPS.

Fixes #678.

cc @joshdata