### PR TITLE
Remove HTTP URIs, yank a couple bill functions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
 This application makes use of various Commonsware libraries. These, along with their respective Apache licenses, are:
 
   com.commonsware.cwac.wakeful:
-  http://github.com/commonsguy/cwac-wakeful/blob/master/LICENSE
+  https://github.com/commonsguy/cwac-wakeful/blob/master/LICENSE
 
   com.commonsware.cwac.merge:
-  http://github.com/commonsguy/cwac-merge/blob/master/LICENSE
+  https://github.com/commonsguy/cwac-merge/blob/master/LICENSE
 
   com.commonsware.cwac.sacklist:
-  http://github.com/commonsguy/cwac-sacklist/blob/master/LICENSE
+  https://github.com/commonsguy/cwac-sacklist/blob/master/LICENSE
 
 ==================
 
@@ -20,7 +20,7 @@ geojson-jackson-1.1.jar
 jackson-annotations-2.3.0.jar
 jackson-core-2.3.1.jar
 jackson-databind-2.3.1.jar
-  http://jackson.codehaus.org
+  https://github.com/FasterXML/jackson
   Apache License 2.0
 
 ==================

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We use [Github Issues](https:/github.com/konklone/congress-android/issues) for i
 
 When setting this up:
 
-* copy `keys.xml.example` to `app/src/main/res/values/keys.xml` and fill in your [Sunlight API](http://services.sunlightlabs.com) key.
+* copy `keys.xml.example` to `app/src/main/res/values/keys.xml` and fill in your [Pro Publica API](https://projects.propublica.org/api-docs/congress-api/) key.
 * copy `tracker.xml.example` to `app/src/main/res/xml/tracker.xml`
 
 If you're using Google Analytics, fill in `app/src/main/res/xml/tracker.xml`'s `ga_trackingId` field with your Google Analytics profile tracking ID. (Make sure you've set up a profile in Google Analytics first.)

--- a/app/src/main/java/com/commonsware/cwac/merge/MergeAdapter.java
+++ b/app/src/main/java/com/commonsware/cwac/merge/MergeAdapter.java
@@ -5,7 +5,7 @@
 	Licensed under the Apache License, Version 2.0 (the "License"); you may
 	not use this file except in compliance with the License. You may obtain
 	a copy of the License at
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://www.apache.org/licenses/LICENSE-2.0
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/app/src/main/java/com/commonsware/cwac/sacklist/SackOfViewsAdapter.java
+++ b/app/src/main/java/com/commonsware/cwac/sacklist/SackOfViewsAdapter.java
@@ -5,7 +5,7 @@
 	Licensed under the Apache License, Version 2.0 (the "License"); you may
 	not use this file except in compliance with the License. You may obtain
 	a copy of the License at
-		http://www.apache.org/licenses/LICENSE-2.0
+		https://www.apache.org/licenses/LICENSE-2.0
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/app/src/main/java/com/commonsware/cwac/wakeful/AlarmReceiver.java
+++ b/app/src/main/java/com/commonsware/cwac/wakeful/AlarmReceiver.java
@@ -4,7 +4,7 @@
   Licensed under the Apache License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain
   a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/app/src/main/java/com/commonsware/cwac/wakeful/WakefulIntentService.java
+++ b/app/src/main/java/com/commonsware/cwac/wakeful/WakefulIntentService.java
@@ -4,7 +4,7 @@
   Licensed under the Apache License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain
   a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/app/src/main/java/com/sunlightlabs/android/congress/BillPager.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/BillPager.java
@@ -140,27 +140,9 @@ public class BillPager extends Activity implements HasActionMenu {
 		
 		toggleFavoriteStar(cursor.getCount() == 1);
 		
-		ActionBarUtils.setActionButton(this, R.id.action_2, R.drawable.share, new View.OnClickListener() {
-			public void onClick(View v) {
-				Analytics.billShare(BillPager.this, bill.id);
-	    		Intent intent = new Intent(Intent.ACTION_SEND).setType("text/plain")
-	    				.putExtra(Intent.EXTRA_TEXT, shareText())
-	    				.putExtra(Intent.EXTRA_SUBJECT, shareSubject());
-	    		startActivity(Intent.createChooser(intent, "Share bill via:"));
-			}
-		});
-		
 		ActionBarUtils.setActionMenu(this, R.menu.bill);
 	}
 	
-	public String shareText() {
-		return bill.sunlightShortUrl();
-	}
-	
-	public String shareSubject() {
-		return Bill.formatCode(bill.id);
-	}
-
 	private void toggleFavoriteStar(boolean enabled) {
 		if (enabled)
 			ActionBarUtils.setActionIcon(this, R.id.action_1, R.drawable.star_on);
@@ -212,11 +194,6 @@ public class BillPager extends Activity implements HasActionMenu {
     		Analytics.billGovTrack(this, bill.id);
     		if (bill.urls != null && bill.urls.containsKey("govtrack"))
     			startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(bill.urls.get("govtrack"))));
-    		break;
-    	case R.id.opencongress:
-    		Analytics.billOpenCongress(this, bill.id);
-    		if (bill.urls != null && bill.urls.containsKey("opencongress"))
-    			startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(bill.urls.get("opencongress"))));
     		break;
     	}
 	}

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Analytics.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Analytics.java
@@ -144,54 +144,46 @@ public class Analytics {
 		return intent;
 	}
 	
-	
-	
 	/*
 	 * Event definitions
 	 */
 	
 	// types of entry into the application
-		public static final String ENTRY_MAIN = "main";
-		public static final String ENTRY_SHORTCUT = "shortcut";
-		public static final String ENTRY_NOTIFICATION = "notification";
+	public static final String ENTRY_MAIN = "main";
+	public static final String ENTRY_NOTIFICATION = "notification";
 
 
-		// categories of events
-		public static final String EVENT_FAVORITE = "favorites";
-		public static final String EVENT_NOTIFICATION = "notifications";
-		public static final String EVENT_LEGISLATOR = "legislator";
-		public static final String EVENT_BILL = "bill";
-		public static final String EVENT_ANALYTICS = "analytics";
-		public static final String EVENT_ENTRY = "entry";
-		public static final String EVENT_ABOUT = "about";
-		public static final String EVENT_CHANGELOG = "changelog";
-		public static final String EVENT_REVIEW = "review"; // values will be "google" or "amazon"
-        public static final String EVENT_PING = "ping";
-		
-		// event values
-		public static final String FAVORITE_ADD_LEGISLATOR = "add_legislator";
-		public static final String FAVORITE_REMOVE_LEGISLATOR = "remove_legislator";
-		public static final String FAVORITE_ADD_BILL = "add_bill";
-		public static final String FAVORITE_REMOVE_BILL = "remove_bill";
-		public static final String NOTIFICATION_ADD = "subscribe";
-		public static final String NOTIFICATION_REMOVE = "unsubscribe";
-		public static final String LEGISLATOR_CALL = "call";
-		public static final String LEGISLATOR_WEBSITE = "website";
-		public static final String LEGISLATOR_TWITTER = "twitter";
-		public static final String LEGISLATOR_YOUTUBE = "youtube";
-		public static final String LEGISLATOR_FACEBOOK = "facebook";
-		public static final String LEGISLATOR_DISTRICT = "district";
-		public static final String LEGISLATOR_CONTACTS = "contacts";
-		public static final String BILL_SHARE = "share";
-		public static final String BILL_TEXT = "text";
-		public static final String BILL_OPENCONGRESS = "opencongress";
-		public static final String BILL_GOVTRACK = "govtrack";
-		public static final String BILL_UPCOMING = "upcoming";
-		public static final String BILL_UPCOMING_MORE = "upcoming_more";
-		public static final String ANALYTICS_DISABLE = "disable";
-		public static final String ABOUT_VALUE = "open";
-		public static final String CHANGELOG_VALUE = "open";
-        public static final String PING_VALUE = "ping";
+	// categories of events
+	public static final String EVENT_FAVORITE = "favorites";
+	public static final String EVENT_NOTIFICATION = "notifications";
+	public static final String EVENT_LEGISLATOR = "legislator";
+	public static final String EVENT_BILL = "bill";
+	public static final String EVENT_ANALYTICS = "analytics";
+	public static final String EVENT_ABOUT = "about";
+	public static final String EVENT_CHANGELOG = "changelog";
+	public static final String EVENT_REVIEW = "review"; // values will be "google" or "amazon"
+	public static final String EVENT_PING = "ping";
+
+	// event values
+	public static final String FAVORITE_ADD_LEGISLATOR = "add_legislator";
+	public static final String FAVORITE_REMOVE_LEGISLATOR = "remove_legislator";
+	public static final String FAVORITE_ADD_BILL = "add_bill";
+	public static final String FAVORITE_REMOVE_BILL = "remove_bill";
+	public static final String NOTIFICATION_ADD = "subscribe";
+	public static final String NOTIFICATION_REMOVE = "unsubscribe";
+	public static final String LEGISLATOR_CALL = "call";
+	public static final String LEGISLATOR_WEBSITE = "website";
+	public static final String LEGISLATOR_TWITTER = "twitter";
+	public static final String LEGISLATOR_YOUTUBE = "youtube";
+	public static final String LEGISLATOR_FACEBOOK = "facebook";
+	public static final String LEGISLATOR_CONTACTS = "contacts";
+	public static final String BILL_TEXT = "text";
+	public static final String BILL_GOVTRACK = "govtrack";
+	public static final String BILL_UPCOMING = "upcoming";
+	public static final String ANALYTICS_DISABLE = "disable";
+	public static final String ABOUT_VALUE = "open";
+	public static final String CHANGELOG_VALUE = "open";
+	public static final String PING_VALUE = "ping";
 
     public static void ping(Activity activity) {
         event(activity, EVENT_PING, PING_VALUE, null);
@@ -241,40 +233,20 @@ public class Analytics {
 		event(activity, EVENT_LEGISLATOR, network, bioguideId);
 	}
 	
-	public static void legislatorDistrict(Activity activity, String bioguideId) {
-		event(activity, EVENT_LEGISLATOR, LEGISLATOR_DISTRICT, bioguideId);
-	}
-	
 	public static void legislatorContacts(Activity activity, String bioguideId) {
 		event(activity, EVENT_LEGISLATOR, LEGISLATOR_CONTACTS, bioguideId);
-	}
-	
-	public static void billShare(Activity activity, String billId) {
-		event(activity, EVENT_BILL, BILL_SHARE, billId);
 	}
 	
 	public static void billText(Activity activity, String billId) {
 		event(activity, EVENT_BILL, BILL_TEXT, billId);
 	}
 	
-	public static void billOpenCongress(Activity activity, String billId) {
-		event(activity, EVENT_BILL, BILL_OPENCONGRESS, billId);
-	}
-	
 	public static void billGovTrack(Activity activity, String billId) {
 		event(activity, EVENT_BILL, BILL_GOVTRACK, billId);
 	}
 	
-	public static void billUpcomingMore(Activity activity, String sourceType) {
-		event(activity, EVENT_BILL, BILL_UPCOMING_MORE, sourceType);
-	}
-	
 	public static void billUpcoming(Activity activity, String billId) {
 		event(activity, EVENT_BILL, BILL_UPCOMING, billId);
-	}
-	
-	public static void markEntry(Activity activity, String source) {
-		event(activity, EVENT_ENTRY, source, source);
 	}
 	
 	public static void analyticsDisable(Activity activity) {

--- a/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
@@ -177,13 +177,9 @@ public class Bill implements Serializable {
 	
 	// next best thing to official, easily calculable from bill fields
 	public String fallbackTextUrl() {
-		return "http://www.govtrack.us/congress/bills/" + congress + "/" + bill_type + number + "/text";
+		return "https://www.govtrack.us/congress/bills/" + congress + "/" + bill_type + number + "/text";
 	}
-	
-	public String sunlightShortUrl() {
-		return "http://cngr.es/b/" + this.id;
-	}
-	
+
 	public static String formatSummary(String summary, String short_title) {
 		String formatted = summary;
 		formatted = formatted.replaceFirst("^\\d+\\/\\d+\\/\\d+--.+?\\.\\s*", "");

--- a/app/src/main/resources/com/commonsware/cwac/merge/LICENSE
+++ b/app/src/main/resources/com/commonsware/cwac/merge/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/app/src/main/resources/com/commonsware/cwac/sacklist/LICENSE
+++ b/app/src/main/resources/com/commonsware/cwac/sacklist/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This updates a ton of in-app and documentation URLs from `http:` to `https:`, and removes a couple of bill sharing functions (Sunlight short URLs and OpenCongress URLs).