### PR TITLE
Port over more legislator API calls

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
@@ -351,7 +351,7 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 			try {
 				switch (context.type) {
 				case SEARCH_LASTNAME:
-					temp = LegislatorService.allWhere("query", context.lastName);
+					temp = LegislatorService.allByLastName(context.lastName);
 					break;
 				case SEARCH_COMMITTEE:
 					temp = CommitteeService.find(context.committee.id).members;
@@ -363,7 +363,7 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 					temp = BillService.find(context.billId, new String[] {"cosponsors"}).cosponsors;
 					break;
 				case SEARCH_CHAMBER:
-					return LegislatorService.allWhere("chamber", context.chamber);
+					return LegislatorService.allByChamber(context.chamber);
 				default:
 					return legislators;
 				}

--- a/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
@@ -86,11 +86,11 @@ public class Bill implements Serializable {
 		return Pattern.compile("^(hr|hres|hjres|hconres|s|sres|sjres|sconres)(\\d+)$").matcher(code).matches();
 	}
 	
-	public static String currentSession() {
+	public static int currentCongress() {
 		int year = Calendar.getInstance().get(Calendar.YEAR);
-		return "" + (((year + 1901) / 2) - 894);
+		return ((year + 1) / 2) - 894;
 	}
-	
+
 	public static String matchText(String field) {
 		if (field.equals("text"))
 			return "text";

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -6,7 +6,8 @@ public class Legislator implements Comparable<Legislator>, Serializable {
 	private static final long serialVersionUID = 1L;
 	
 	public String bioguide_id, govtrack_id, thomas_id;
-	public String first_name, last_name, nickname, name_suffix;
+	public String first_name, middle_name, last_name;
+	public String nickname, name_suffix; // TODO: remove
 	public String title, party, state, district, chamber;
 	public String gender, office, website, phone;
 	public String twitter_id, youtube_id, facebook_id; 

--- a/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
@@ -44,22 +44,24 @@ public class LegislatorService {
     }
 
     // Expensive: request data for both chambers, and search client-side.
-    public static List<Legislator> allByLastName(String lastName) throws CongressException {
+    public static List<Legislator> allByLastName(String name) throws CongressException {
         List<Legislator> members = new ArrayList<Legislator>();
         members.addAll(allByChamber("senate"));
         members.addAll(allByChamber("house"));
 
-        String lower = lastName.toLowerCase();
+        String lower = name.toLowerCase();
 
         List<Legislator> matches = new ArrayList<Legislator>();
 
         // client-side match, nice
         for (int i=0; i<members.size(); i++) {
             Legislator member = members.get(i);
-            if (member.last_name != null) {
-                if (member.last_name.toLowerCase().equals(lower))
-                    matches.add(member);
-            }
+            if (member.last_name != null && member.last_name.toLowerCase().contains(lower))
+                matches.add(member);
+            else if (member.first_name != null && member.first_name.toLowerCase().contains(lower))
+                matches.add(member);
+            else if (member.middle_name != null && member.middle_name.toLowerCase().contains(lower))
+                matches.add(member);
         }
 
         return matches;
@@ -104,6 +106,8 @@ public class LegislatorService {
 
         if (!json.isNull("first_name"))
             legislator.first_name = json.getString("first_name");
+        if (!json.isNull("middle_name"))
+            legislator.middle_name = json.getString("middle_name");
         if (!json.isNull("last_name"))
             legislator.last_name = json.getString("last_name");
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
@@ -1,5 +1,6 @@
 package com.sunlightlabs.congress.services;
 
+import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 
@@ -12,26 +13,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+// See Pro Publica Congress API docs:
+// https://projects.propublica.org/api-docs/congress-api/endpoints/
+
 public class LegislatorService {
-
-	private static String[] basicFields = new String[] {
-		"bioguide_id", "thomas_id", "govtrack_id",
-		"in_office", "party", "gender", "state", "state_name",
-		"district", "title", "chamber", "senate_class", "birthday",
-		"term_start", "term_end", "leadership_role",
-		"first_name", "nickname", "middle_name", "last_name", "name_suffix",
-		"phone", "website", "office",
-		"twitter_id", "youtube_id", "facebook_id"
-	};
-
-	public static List<Legislator> allWhere(String key, String value) throws CongressException {
-		Map<String,String> params = new HashMap<String,String>();
-		params.put(key, value);
-		params.put("order", "last_name__asc");
-		params.put("per_page", "all");
-
-		return legislatorsFor(Congress.url("legislators", basicFields, params));
-	}
 
 	public static List<Legislator> allForState(String state) throws CongressException {
         // /members/{chamber}/{state}/current.json
@@ -58,9 +43,43 @@ public class LegislatorService {
         return members;
     }
 
+    // Expensive: request data for both chambers, and search client-side.
+    public static List<Legislator> allByLastName(String lastName) throws CongressException {
+        List<Legislator> members = new ArrayList<Legislator>();
+        members.addAll(allByChamber("senate"));
+        members.addAll(allByChamber("house"));
+
+        String lower = lastName.toLowerCase();
+
+        List<Legislator> matches = new ArrayList<Legislator>();
+
+        // client-side match, nice
+        for (int i=0; i<members.size(); i++) {
+            Legislator member = members.get(i);
+            if (member.last_name != null) {
+                if (member.last_name.toLowerCase().equals(lower))
+                    matches.add(member);
+            }
+        }
+
+        return matches;
+    }
+
+    public static List<Legislator> allByChamber(String chamber) throws CongressException {
+        // /{congress}/{chamber}/members.json
+        String[] endpoint = { String.valueOf(Bill.currentCongress()), chamber, "members" };
+        List<Legislator> members = proPublicaLegislatorsFor(ProPublica.url(endpoint));
+
+        // The 'chamber' field is omitted in responses
+        for (int i=0; i<members.size(); i++)
+            members.get(i).chamber = chamber;
+
+        return members;
+    }
+
 	public static Legislator find(String bioguideId) throws CongressException {
-        String[] paths = new String[] {"members", bioguideId};
-		return proPublicaLegislatorFor(ProPublica.url(paths));
+        String[] endpoint = new String[] {"members", bioguideId};
+		return proPublicaLegislatorFor(ProPublica.url(endpoint));
 	}
 	
 	/* JSON parsers, also useful for other service endpoints within this package */
@@ -157,6 +176,9 @@ public class LegislatorService {
 
             if (!json.isNull("party"))
                 legislator.party = json.getString("party");
+
+            if (!json.isNull("state"))
+                legislator.state = json.getString("state");
 
             if (!json.isNull("district"))
                 legislator.district = json.getString("district");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,7 +126,7 @@
     <string name="menu_main_floor_updates">The Floor</string>
     <string name="menu_main_hearings">Hearings</string>
     
-    <string name="search_legislators_hint">Search by last name</string>
+    <string name="search_legislators_hint">Search by name</string>
     <string name="search_legislators_label">Lawmakers</string>
     <string name="search_bills_hint">Search bills</string>
     <string name="search_bills_label">Bills</string>


### PR DESCRIPTION
This ports over the name search and chamber search calls to use the Pro Publica Congress API.

The name search was previously done server-side, and only by a last name filter. The search is now more expensive and done client-side, after fetching both chambers' worth of members using 2 API calls, but the name search is also now more flexible, and will match on any fragment in the first, middle, or last names.