### PR TITLE
Try to fix a few reported crashes

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/FragmentUtils.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/FragmentUtils.java
@@ -36,15 +36,6 @@ public class FragmentUtils {
 		view.findViewById(R.id.refresh).setVisibility(View.GONE);
 		view.findViewById(R.id.loading).setVisibility(View.VISIBLE);
 	}
-	
-	public static void showBack(Fragment fragment, String message) {
-		View view = fragment.getView();
-		view.findViewById(R.id.loading).setVisibility(View.GONE);
-		TextView messageView = (TextView) view.findViewById(R.id.empty_message);
-		messageView.setText(message);
-		messageView.setVisibility(View.VISIBLE);
-		view.findViewById(R.id.back).setVisibility(View.VISIBLE);	
-	}
 
 	public static void showRefresh(Fragment fragment, String message) {
 		View view = fragment.getView();
@@ -68,17 +59,14 @@ public class FragmentUtils {
 		((TextView) fragment.getView().findViewById(R.id.loading_message)).setText(message);
 	}
 	
-	
-	public static void showBack(Fragment fragment, int message) {
-		FragmentUtils.showBack(fragment, fragment.getActivity().getResources().getString(message));
-	}
-	
 	public static void showEmpty(Fragment fragment, int message) {
-		FragmentUtils.showEmpty(fragment, fragment.getActivity().getResources().getString(message));
+		if (fragment.getActivity() != null)
+			FragmentUtils.showEmpty(fragment, fragment.getActivity().getResources().getString(message));
 	}
 	
 	public static void showRefresh(Fragment fragment, int message) {
-		FragmentUtils.showRefresh(fragment, fragment.getActivity().getResources().getString(message));
+		if (fragment.getActivity() != null)
+			FragmentUtils.showRefresh(fragment, fragment.getActivity().getResources().getString(message));
 	}
 	
 }

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/LegislatorImage.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/LegislatorImage.java
@@ -49,15 +49,14 @@ public class LegislatorImage {
 	 * overhaul. This should likely be refactored out at some point in favor of the Picasso
 	 * async loader.
 	 */
-	public static Drawable getImage(
-			String bioguideId,
-			String imageSize,
-			Context context
-	) {
+	public static Drawable getImage(String bioguideId, String imageSize, Context context) {
 		String url = LegislatorImage.getImageURL(bioguideId, imageSize);
 		RequestCreator rc = Picasso.with(context)
 				.load(url)
 				.placeholder(R.drawable.loading_photo);
+
+		if (context == null) return null;
+		
 		try {
 			return new BitmapDrawable(context.getResources(), rc.get());
 		} catch (IOException e) {

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/LegislatorImage.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/LegislatorImage.java
@@ -50,12 +50,12 @@ public class LegislatorImage {
 	 * async loader.
 	 */
 	public static Drawable getImage(String bioguideId, String imageSize, Context context) {
-		String url = LegislatorImage.getImageURL(bioguideId, imageSize);
+        if (context == null) return null;
+
+        String url = LegislatorImage.getImageURL(bioguideId, imageSize);
 		RequestCreator rc = Picasso.with(context)
 				.load(url)
 				.placeholder(R.drawable.loading_photo);
-
-		if (context == null) return null;
 
 		try {
 			return new BitmapDrawable(context.getResources(), rc.get());

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/LegislatorImage.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/LegislatorImage.java
@@ -56,7 +56,7 @@ public class LegislatorImage {
 				.placeholder(R.drawable.loading_photo);
 
 		if (context == null) return null;
-		
+
 		try {
 			return new BitmapDrawable(context.getResources(), rc.get());
 		} catch (IOException e) {


### PR DESCRIPTION
Fixes a few `NullPointerException`s and `IllegalArgumentException`s I've seen coming in over the last few releases. It looks like they're all from edge case race conditions where people navigate away from screens and cause their Activities or Contexts to get destroyed, and we weren't properly handling the possibility that they would be `null` by the time we were referring to them.