### PR TITLE
Migrate upcoming hearings to use the Pro Publica API

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/HearingPager.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/HearingPager.java
@@ -2,6 +2,7 @@ package com.sunlightlabs.android.congress;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.view.View;
 
 import com.sunlightlabs.android.congress.fragments.HearingListFragment;
 import com.sunlightlabs.android.congress.utils.ActionBarUtils;
@@ -21,9 +22,10 @@ public class HearingPager extends Activity {
 	}
 
 	private void setupPager() {
+        findViewById(R.id.pager_titles).setVisibility(View.GONE);
+
 		TitlePageAdapter adapter = new TitlePageAdapter(this);
-		adapter.add("house", R.string.tab_house, HearingListFragment.forChamber("house"));
-		adapter.add("senate", R.string.tab_senate, HearingListFragment.forChamber("senate"));
+		adapter.add("upcoming", R.string.tab_upcoming_hearings, HearingListFragment.upcoming());
 		
 		String chamber = getIntent().getStringExtra("chamber");
 		if (chamber != null && chamber.equals("senate"))

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/BillListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/BillListFragment.java
@@ -33,10 +33,9 @@ import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 import com.sunlightlabs.congress.services.BillService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 public class BillListFragment extends ListFragment implements PaginationListener.Paginates {
-	
-	public static final int PER_PAGE = 20;
 	
 	public static final int BILLS_ACTIVE = 0;
 	public static final int BILLS_ALL = 1;
@@ -157,7 +156,7 @@ public class BillListFragment extends ListFragment implements PaginationListener
 	}
 	
 	public void setupControls() {
-		((Button) getView().findViewById(R.id.refresh)).setOnClickListener(new View.OnClickListener() {
+		getView().findViewById(R.id.refresh).setOnClickListener(new View.OnClickListener() {
 			public void onClick(View v) {
 				refresh();
 			}
@@ -232,7 +231,7 @@ public class BillListFragment extends ListFragment implements PaginationListener
 		}
 		
 		// only re-enable the pagination if we got a full page back
-		if (bills.size() >= PER_PAGE)
+		if (bills.size() >= ProPublica.PER_PAGE)
 			getListView().setOnScrollListener(pager);
 	}
 	

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/HearingListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/HearingListFragment.java
@@ -26,6 +26,7 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Hearing;
 import com.sunlightlabs.congress.services.HearingService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 public class HearingListFragment extends ListFragment {
 	private List<Hearing> hearings;
@@ -159,8 +160,13 @@ public class HearingListFragment extends ListFragment {
 				view = inflater.inflate(R.layout.hearing, null);
 			
 			Date date = hearing.occursAt;
-			String month = new SimpleDateFormat("MMM d").format(date).toUpperCase();
-			String time = new SimpleDateFormat("h:mm aa").format(date);
+            SimpleDateFormat dateDisplay = new SimpleDateFormat("MMM d");
+            SimpleDateFormat timeDisplay = new SimpleDateFormat("h:mm aa");
+            dateDisplay.setTimeZone(ProPublica.CONGRESS_TIMEZONE);
+            timeDisplay.setTimeZone(ProPublica.CONGRESS_TIMEZONE);
+
+			String month = dateDisplay.format(date).toUpperCase();
+			String time = timeDisplay.format(date) + " ET";
 
             String chamberCap = hearing.chamber.substring(0, 1).toUpperCase() + hearing.chamber.substring(1);
 			String name = chamberCap + " " + hearing.committee.name;

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsActiveSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsActiveSubscriber.java
@@ -13,6 +13,7 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.services.BillService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 public class BillsActiveSubscriber extends Subscriber {
 	
@@ -35,7 +36,7 @@ public class BillsActiveSubscriber extends Subscriber {
 	
 	@Override
 	public String notificationMessage(Subscription subscription, int results) {
-		if (results == BillListFragment.PER_PAGE)
+		if (results == ProPublica.PER_PAGE)
 			return results + " or more new active bills .";
 		else if (results > 1)
 			return results + " new active bills.";

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsLawSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsLawSubscriber.java
@@ -11,6 +11,7 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.services.BillService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 import java.util.List;
 
@@ -35,7 +36,7 @@ public class BillsLawSubscriber extends Subscriber {
 	
 	@Override
 	public String notificationMessage(Subscription subscription, int results) {
-		if (results == BillListFragment.PER_PAGE)
+		if (results == ProPublica.PER_PAGE)
 			return results + " or more bills signed into Law.";
 		else if (results > 1)
 			return results + " bills signed into Law.";

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsLegislatorSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsLegislatorSubscriber.java
@@ -12,6 +12,7 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.services.BillService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 public class BillsLegislatorSubscriber extends Subscriber {
 
@@ -33,7 +34,7 @@ public class BillsLegislatorSubscriber extends Subscriber {
 	
 	@Override
 	public String notificationMessage(Subscription subscription, int results) {
-		if (results == BillListFragment.PER_PAGE)
+		if (results == ProPublica.PER_PAGE)
 			return results + " or more new bills sponsored.";
 		else if (results > 1)
 			return results + " new bills sponsored.";

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsRecentSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsRecentSubscriber.java
@@ -13,6 +13,7 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.services.BillService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 public class BillsRecentSubscriber extends Subscriber {
 
@@ -35,7 +36,7 @@ public class BillsRecentSubscriber extends Subscriber {
 	
 	@Override
 	public String notificationMessage(Subscription subscription, int results) {
-		if (results == BillListFragment.PER_PAGE)
+		if (results == ProPublica.PER_PAGE)
 			return results + " or more new bills.";
 		else if (results > 1)
 			return results + " newly introduced bills.";

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsSearchSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/BillsSearchSubscriber.java
@@ -14,6 +14,7 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.services.BillService;
+import com.sunlightlabs.congress.services.ProPublica;
 
 public class BillsSearchSubscriber extends Subscriber {
 
@@ -39,7 +40,7 @@ public class BillsSearchSubscriber extends Subscriber {
 	
 	@Override
 	public String notificationMessage(Subscription subscription, int results) {
-		if (results == BillListFragment.PER_PAGE)
+		if (results == ProPublica.PER_PAGE)
 			return results + " or more new bills for search \"" + subscription.data + "\".";
 		else if (results > 1)
 			return results + " new bills for search \"" + subscription.data + "\".";

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TabHost;
@@ -31,8 +32,6 @@ import java.util.GregorianCalendar;
 public class Utils {
 	public static final String TAG = "Congress";
 	
-	public static SimpleDateFormat timeFormat = new SimpleDateFormat("h:mm aa");
-	
 	public static void setupAPI(Context context) {
 		Resources resources = context.getResources();
 		
@@ -45,6 +44,12 @@ public class Utils {
         ProPublica.baseUrl = resources.getString(R.string.propublica_api_endpoint);
         ProPublica.userAgent = resources.getString(R.string.api_user_agent);
         ProPublica.apiKey = resources.getString(R.string.propublica_api_key);
+    }
+
+    // decode HTML entities like &#39;
+    // TODO: when moving to API level 24+, use proper Html methods
+    public static String decodeHTML(String input) {
+        return input.replace("&#39;", "'");
     }
 
 	public static void alert(Context context, String msg) {
@@ -321,15 +326,6 @@ public class Utils {
 			nearby.setText(fullDate);
 			full.setVisibility(View.GONE);
 		}
-		
-		return view;
-	}
-	
-	public static View dateTimeView(Context context, Date subject) {
-		View view = LayoutInflater.from(context).inflate(R.layout.list_item_date, null);
-		
-		((TextView) view.findViewById(R.id.date_left)).setText(Utils.nearbyOrFullDate(subject));
-		((TextView) view.findViewById(R.id.date_right)).setText(timeFormat.format(subject));
 		
 		return view;
 	}

--- a/app/src/main/java/com/sunlightlabs/congress/models/Hearing.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Hearing.java
@@ -3,14 +3,12 @@ package com.sunlightlabs.congress.models;
 import java.util.Date;
 
 public class Hearing {
-	public int congress;
 	public String chamber;
 	public Date occursAt;
 	public Committee committee;
 	public String description;
 	public String room;
-	public boolean dc;
-	
+
 	// House only
 	public String url;
 	public String hearingType;

--- a/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
@@ -40,7 +40,7 @@ public class ProPublica {
     public static SimpleDateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
     // Pro Publica Per Page
-    public static int PPPP = 20;
+    public static int PER_PAGE = 20;
 
     // filled in by the client in keys.xml
     public static String baseUrl = null;
@@ -82,7 +82,7 @@ public class ProPublica {
 
         // Only use for query string is an "offset" for pagination as needed
         if (page > 0) {
-            int offset = (page - 1) * PPPP;
+            int offset = (page - 1) * PER_PAGE;
             params.put("offset", String.valueOf(offset));
         }
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
@@ -30,8 +30,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class ProPublica {
+
+    public static TimeZone CONGRESS_TIMEZONE = TimeZone.getTimeZone("America/New_York");
+    public static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    public static SimpleDateFormat timeFormat = new SimpleDateFormat("hh:mm:ss");
+    public static SimpleDateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
     // Pro Publica Per Page
     public static int PPPP = 20;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,7 @@
     <string name="tab_subscriptions">Subscriptions</string>
     <string name="tab_house">House</string>
     <string name="tab_senate">Senate</string>
+    <string name="tab_upcoming_hearings">Upcoming</string>
     <string name="tab_joint">Joint</string>
     
     <string name="image_star">Star</string>


### PR DESCRIPTION
Migrates upcoming hearings to the [Pro Publica Congress API](https://projects.propublica.org/api-docs/congress-api/endpoints/#get-recent-committee-hearings).

This also basically just fixes the hearings screen, which has been busted for unknown reasons.

This also makes a tweak to always show the dates and times in Eastern Time (and to mark the time as `ET` explicitly), to avoid mistakes or ambiguity around hearings that almost always happen in Washington, DC.

The API doesn't allow filtering by chamber, so this merge the two tabs into one combined feed of House and Senate hearings. I think this makes a fair amount of sense, unless I get user feedback otherwise.

Fixes #671.