### PR TITLE
Fix bug in detecting whether votes pass or fail

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/BillVoteFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/BillVoteFragment.java
@@ -138,11 +138,11 @@ public class BillVoteFragment extends ListFragment implements LoadBillTask.Loads
 			((TextView) view.findViewById(R.id.date)).setText(timestamp);
 			
 			TextView resultView = (TextView) view.findViewById(R.id.result);
-			String result = vote.result;
+
 			String resultDisplay;
-			if (result.equals("pass"))
+			if (vote.passed())
 				resultDisplay = "Passed";
-			else // if (result.equals("fail"))
+			else
 				resultDisplay = "Failed";
 				
 			resultView.setText(resultDisplay + " the " + Utils.capitalize(vote.chamber));

--- a/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
@@ -70,6 +70,15 @@ public class Bill implements Serializable {
 
         // TODO: move this back to voted_at
 		public Date voted_on;
+
+		public boolean passed() {
+			if (this.result == null) return false;
+
+            Pattern pattern = Pattern.compile("passed", Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(this.result);
+            boolean passed = matcher.find();
+            return passed;
+		}
 	}
 	
 	public static String normalizeCode(String code) {

--- a/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
@@ -1,8 +1,6 @@
 package com.sunlightlabs.congress.services;
 
 import com.sunlightlabs.congress.models.Bill;
-import com.sunlightlabs.congress.models.Bill.Action;
-import com.sunlightlabs.congress.models.Bill.Vote;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 
@@ -12,8 +10,6 @@ import org.json.JSONObject;
 
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +186,7 @@ public class BillService {
 
                 vote.voted_on = ProPublica.parseDateOnly(object.getString("date"));
                 vote.chamber = object.getString("chamber").toLowerCase();
-                vote.result = object.getString("result");
+                vote.result = object.getString("result").toLowerCase();
                 vote.question = object.getString("question");
                 vote.yes = object.getInt("total_yes");
                 vote.no = object.getInt("total_no");


### PR DESCRIPTION
Uses a regex on bill vote results to tell whether a bill vote passed or failed.

Filed https://github.com/propublica/congress-api-docs/issues/85 in the hopes of being able to remove this workaround in the future.

Fixes #708.