### PR TITLE
Migrates floor updates to use the Pro Publica API

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
@@ -198,7 +198,7 @@ public class FloorUpdateFragment extends ListFragment implements PaginationListe
 				
 				Linkify.addLinks(text, 
 						Pattern.compile("(S\\.|H\\.)(\\s?J\\.|\\s?R\\.|\\s?Con\\.| ?)(\\s?Res\\.)*\\s?\\d+", Pattern.CASE_INSENSITIVE), 
-						"congress://com.sunlightlabs.android.congress/bill/" + update.congress+ "/");
+						"congress://com.sunlightlabs.android.congress/bill/" + update.congress + "/");
 				
 				Linkify.addLinks(text,
 						Pattern.compile("Roll (?:no.|Call) (\\d+)"),
@@ -233,7 +233,7 @@ public class FloorUpdateFragment extends ListFragment implements PaginationListe
 			List<FloorUpdate> updates = new ArrayList<FloorUpdate>();
 			
 			try {
-				updates = FloorUpdateService.latest(chamber, page, PER_PAGE);
+				updates = FloorUpdateService.latest(chamber, page);
 			} catch (CongressException e) {
 				Log.e(Utils.TAG, "Error while loading floor updates for " + chamber + ": " + e.getMessage());
 				this.exception = e;

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/FloorUpdatesSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/FloorUpdatesSubscriber.java
@@ -26,7 +26,7 @@ public class FloorUpdatesSubscriber extends Subscriber {
 		String chamber = subscription.data;
 		
 		try {
-			return FloorUpdateService.latest(chamber, 1, FloorUpdateFragment.PER_PAGE);
+			return FloorUpdateService.latest(chamber, 1);
 		} catch (CongressException e) {
 			Log.w(Utils.TAG, "Could not fetch the latest floor updates for " + subscription, e);
 			return null;

--- a/app/src/main/java/com/sunlightlabs/congress/models/FloorUpdate.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/FloorUpdate.java
@@ -7,7 +7,6 @@ import java.util.List;
 public class FloorUpdate implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-    public String id;
 	public Date timestamp;
 	public Date legislativeDay;
 	public String update;

--- a/app/src/main/java/com/sunlightlabs/congress/models/FloorUpdate.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/FloorUpdate.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public class FloorUpdate implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
-	public List<String> billIds, rollIds, legislatorIds;
+
+    public String id;
 	public Date timestamp;
 	public Date legislativeDay;
 	public String update;

--- a/app/src/main/java/com/sunlightlabs/congress/services/FloorUpdateService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/FloorUpdateService.java
@@ -36,10 +36,7 @@ public class FloorUpdateService {
 	protected static FloorUpdate fromAPI(JSONObject json) throws JSONException, ParseException, CongressException {
 		FloorUpdate update = new FloorUpdate();
 
-        if (!json.isNull("action_id"))
-            update.id = json.getString("action_id");
-
-		if (!json.isNull("description"))
+        if (!json.isNull("description"))
 			update.update = json.getString("description");
 
 		if (!json.isNull("congress"))

--- a/app/src/main/java/com/sunlightlabs/congress/services/HearingService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/HearingService.java
@@ -1,6 +1,7 @@
 package com.sunlightlabs.congress.services;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -22,6 +23,8 @@ import com.sunlightlabs.congress.models.Hearing;
 
 public class HearingService {
 
+    public static String datetimeFormat = "yyyy-MM-dd hh:mm:ss";
+
 	// /{congress}/committees/hearings.json
 	public static List<Hearing> upcoming(int page) throws CongressException {
         String congress = String.valueOf(Bill.currentCongress());
@@ -41,8 +44,9 @@ public class HearingService {
 
         if (!json.isNull("date") && !json.isNull("time")) {
             String timestamp = json.getString("date") + " " + json.getString("time");
-            ProPublica.datetimeFormat.setTimeZone(ProPublica.CONGRESS_TIMEZONE);
-            hearing.occursAt = ProPublica.datetimeFormat.parse(timestamp);
+            SimpleDateFormat format = new SimpleDateFormat(datetimeFormat);
+            format.setTimeZone(ProPublica.CONGRESS_TIMEZONE);
+            hearing.occursAt = format.parse(timestamp);
         }
 
 		// House only

--- a/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
@@ -35,9 +35,9 @@ import java.util.TimeZone;
 public class ProPublica {
 
     public static TimeZone CONGRESS_TIMEZONE = TimeZone.getTimeZone("America/New_York");
-    public static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-    public static SimpleDateFormat timeFormat = new SimpleDateFormat("hh:mm:ss");
-    public static SimpleDateFormat datetimeFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+    public static String dateOnlyFormat = "yyyy-MM-dd";
+    public static String timeOnlyFormat = "hh:mm:ss";
+
 
     // Pro Publica Per Page
     public static int PER_PAGE = 20;
@@ -46,8 +46,6 @@ public class ProPublica {
     public static String baseUrl = null;
     public static String userAgent = null;
     public static String apiKey = null;
-
-    public static final String dateOnlyFormat = "yyyy-MM-dd";
 
     public static String url(String[] components) throws CongressException {
         return url(components, null, -1);
@@ -205,5 +203,12 @@ public class ProPublica {
         calendar.setTime(format.parse(date));
         calendar.set(Calendar.HOUR_OF_DAY, 12);
         return calendar.getTime();
+    }
+
+    // BYO timestamp format
+    public static Date parseTimestamp(String timestamp, String format) throws ParseException {
+        SimpleDateFormat simpleFormat = new SimpleDateFormat(format, Locale.US);
+        simpleFormat.setTimeZone(CONGRESS_TIMEZONE);
+        return simpleFormat.parse(timestamp);
     }
 }


### PR DESCRIPTION
This moves the floor updates feeds to use the Pro Publica Congress API instead of the Sunlight Congress API.

Fixes #663.