### PR TITLE
Put a default API endpoint in keys.xml.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When setting this up:
 
 * copy `keys.xml.example` to `app/src/main/res/values/keys.xml` and:
   * fill in `propublica_api_key` with your [Pro Publica API](https://projects.propublica.org/api-docs/congress-api/) key,
-  * fill in `propublica_api_endpoint` with the base Pro Publica API endpoint you wish to use. This is probably `https://api.propublica.org/congress/v1/`.
+  * fill in `propublica_api_endpoint` with the base Pro Publica API endpoint you wish to use. By default, this is `https://api.propublica.org/congress/v1/`.
 * copy `tracker.xml.example` to `app/src/main/res/xml/tracker.xml`
 
 If you're using Google Analytics, fill in `app/src/main/res/xml/tracker.xml`'s `ga_trackingId` field with your Google Analytics profile tracking ID. (Make sure you've set up a profile in Google Analytics first.)

--- a/keys.xml.example
+++ b/keys.xml.example
@@ -3,7 +3,8 @@
     <string name="contact_email"></string>
     <string name="contact_subject"></string>
 
-   <string name="propublica_api_key">CHANGEME</string>
+    <string name="propublica_api_key">CHANGEME</string>
+    <string name="propublica_api_endpoint">https://api.propublica.org/congress/v1/</string>
     <string name="sunlight_api_key">CHANGEME</string>
     <string name="api_user_agent">CHANGEME</string>
     <string name="api_endpoint">https://congress.api.sunlightfoundation.com</string>


### PR DESCRIPTION
This is a follow-up to #714. I put the recommended API endpoint into the example file.