### PR TITLE
Migrate vote detail screens to the Pro Publica Congress API

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
@@ -109,7 +109,6 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 					String chamber = segments.get(1);
 					String year = segments.get(2);
 					String formattedNumber = segments.get(3);
-                    formattedNumber = "2";
 					id = Roll.normalizeRollId(chamber, year, formattedNumber);
 				}
 			}

--- a/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
@@ -546,13 +546,13 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 			}
 			
 			Roll.Vote vote = getItem(position);
-//			Legislator legislator = vote.voter;
+			Legislator legislator = vote.voter;
 			
 			// used as the hook to get the legislator image in place when it's loaded
 			// and to link to the legislator's activity
 			holder.bioguide_id = vote.voter_id;
 			
-			holder.name.setText("");
+			holder.name.setText(nameFor(legislator));
 			
 			TextView voteView = holder.vote;
 			String value = vote.vote;
@@ -575,10 +575,13 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 			return view;
 		}
 		
-//		public String nameFor(Legislator legislator) {
-//			String position = legislator.party + "-" + legislator.state;
-//			return legislator.last_name + ", " + legislator.first_name + " [" + position + "]";
-//		}
+		public String nameFor(Legislator legislator) {
+			if (legislator.party != null && legislator.state != null && legislator.last_name != null && legislator.first_name != null) {
+				String position = legislator.party + "-" + legislator.state;
+				return legislator.last_name + ", " + legislator.first_name + " [" + position + "]";
+			} else
+				return "";
+		}
 		
 		static class ViewHolder {
 			TextView name, vote;

--- a/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
@@ -109,6 +109,7 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 					String chamber = segments.get(1);
 					String year = segments.get(2);
 					String formattedNumber = segments.get(3);
+                    formattedNumber = "2";
 					id = Roll.normalizeRollId(chamber, year, formattedNumber);
 				}
 			}

--- a/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
@@ -385,7 +385,7 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 			Iterator<Roll.Vote> iter = allVoters.iterator();
 			while (iter.hasNext()) {
 				Roll.Vote vote = iter.next();
-				voterBreakdown.get(vote.vote).add(vote);
+                voterBreakdown.get(vote.vote).add(vote);
 			}
 			
 			// hide loading, show tabs
@@ -564,7 +564,7 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 				view = inflater.inflate(R.layout.legislator_voter, null);
 				
 				holder = new ViewHolder();
-//				holder.name = (TextView) view.findViewById(R.id.name);
+				holder.name = (TextView) view.findViewById(R.id.name);
 				holder.vote = (TextView) view.findViewById(R.id.vote);
 				holder.photo = (ImageView) view.findViewById(R.id.photo);
 				
@@ -581,7 +581,7 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 			// and to link to the legislator's activity
 			holder.bioguide_id = vote.voter_id;
 			
-//			holder.name.setText(nameFor(legislator));
+			holder.name.setText("");
 			
 			TextView voteView = holder.vote;
 			String value = vote.vote;
@@ -610,8 +610,7 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 //		}
 		
 		static class ViewHolder {
-//			TextView name;
-			TextView vote;
+			TextView name, vote;
 			ImageView photo;
 			String bioguide_id;
 			

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
@@ -230,7 +230,7 @@ public class FloorUpdateFragment extends ListFragment implements PaginationListe
 
 		@Override
 		protected List<FloorUpdate> doInBackground(Void... nothing) {
-			List<FloorUpdate> updates = new ArrayList<FloorUpdate>();
+			List<FloorUpdate> updates;
 			
 			try {
 				updates = FloorUpdateService.latest(chamber, page);

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -135,7 +135,7 @@ public class RollListFragment extends ListFragment implements PaginationListener
 	public void onListItemClick(ListView parent, View v, int position, long id) {
 		Roll roll = (Roll) parent.getItemAtPosition(position);
 		if (roll != null) // happened once somehow
-			startActivity(Utils.rollIntent(getActivity(), roll));
+			startActivity(Utils.rollIntent(getActivity(), roll.id));
 	}
 	
 
@@ -213,7 +213,7 @@ public class RollListFragment extends ListFragment implements PaginationListener
 				
 				switch (context.type) {
 				case ROLLS_VOTER:
-					return RollService.latestVotes(context.voter.bioguide_id, context.voter.chamber, page, PER_PAGE);
+					return RollService.latestMemberVotes(context.voter.bioguide_id, context.voter.chamber, page, PER_PAGE);
 				case ROLLS_RECENT:
 					return RollService.latestVotes(page, PER_PAGE);
 				default:
@@ -287,12 +287,12 @@ public class RollListFragment extends ListFragment implements PaginationListener
 			holder.question.setText(Utils.truncate(roll.question, 200));
 			holder.result.setText(resultFor(roll));
 
-            if (roll.bill != null) {
+            if (roll.bill_id != null && roll.bill_title != null) {
                 holder.details.setVisibility(View.VISIBLE);
 
                 String title;
-                if (roll.bill.official_title != null)
-                    title = Utils.truncate(roll.bill.official_title, 200);
+                if (roll.bill_title != null)
+                    title = Utils.truncate(roll.bill_title, 200);
                 else
                     title = "(untitled)";
 

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsLegislatorSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsLegislatorSubscriber.java
@@ -26,7 +26,7 @@ public class RollsLegislatorSubscriber extends Subscriber {
 		String chamber = subscription.data;
 		
 		try {
-			return RollService.latestVotes(subscription.id, chamber, 1, RollListFragment.PER_PAGE);
+			return RollService.latestMemberVotes(subscription.id, chamber, 1, RollListFragment.PER_PAGE);
 		} catch (CongressException e) {
 			Log.w(Utils.TAG, "Could not fetch the latest votes for " + subscription, e);
 			return null;

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsRecentSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsRecentSubscriber.java
@@ -45,8 +45,7 @@ public class RollsRecentSubscriber extends Subscriber {
 
 	@Override
 	public Intent notificationIntent(Subscription subscription) {
-		return new Intent()
-			.setClassName("com.sunlightlabs.android.congress", "com.sunlightlabs.android.congress.MenuVotes");
+		return new Intent().setClassName("com.sunlightlabs.android.congress", "com.sunlightlabs.android.congress.MenuVotes");
 	}
 	
 	@Override

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
@@ -59,11 +59,6 @@ public class Utils {
 	public static void alert(Context context, int msg) {
 		Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
 	}
-
-	public static void alert(Context context, CongressException exception) {
-		String message = exception == null ? "Unhandled error." : exception.getMessage();
-		Toast.makeText(context, message, Toast.LENGTH_LONG).show();
-	}
 	
 	public static String formatRollId(String id) {
 		Roll tempRoll = Roll.splitRollId(id);
@@ -83,14 +78,6 @@ public class Utils {
 			.putExtra("legislator", legislator);
 	}
 
-   public static Intent legislatorLoadIntent(String id, Intent intent) {
-	   return new Intent().setClassName(
-			   "com.sunlightlabs.android.congress",
-			   "com.sunlightlabs.android.congress.LegislatorLoader")
-		   .putExtra("id", id)
-		   .putExtra("intent", intent);
-}
-
 
 	public static Intent billIntent(Context context, Bill bill) {
 		return new Intent(context, BillPager.class)
@@ -103,12 +90,6 @@ public class Utils {
 				"com.sunlightlabs.android.congress",
 				"com.sunlightlabs.android.congress.BillPager")
 			.putExtra("bill_id", billId);
-	}
-	
-	public static Intent rollIntent(Context context, Roll roll) {
-		return new Intent(context, RollInfo.class)
-			.putExtra("id", roll.id)
-			.putExtra("roll", roll);
 	}
 	
 	public static Intent rollIntent(Context context, String rollId) {

--- a/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
@@ -100,8 +100,21 @@ public class Bill implements Serializable {
 	
 	public static int currentCongress() {
 		int year = Calendar.getInstance().get(Calendar.YEAR);
-		return ((year + 1) / 2) - 894;
+		return congressForYear(year);
 	}
+
+	public static int congressForYear(int year) {
+        return ((year + 1) / 2) - 894;
+    }
+
+    public static int sessionForYear(int year) {
+        // odd years are the first session of a 2-year congress
+        if (year % 2 == 1)
+            return 1;
+        // even years are the second session of a 2-year congress
+        else
+            return 2;
+    }
 
 	public static String formatCode(String bill_id) {
 		// [bill_type, number, congress]

--- a/app/src/main/java/com/sunlightlabs/congress/models/Roll.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Roll.java
@@ -9,7 +9,8 @@ import java.util.regex.Pattern;
 
 public class Roll implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
+    // standard names for types of votes
 	public static final String YEA = "Yea";
 	public static final String NAY = "Nay";
 	public static final String NOT_VOTING = "Not Voting";
@@ -19,23 +20,23 @@ public class Roll implements Serializable {
 	public boolean otherVotes = false;
 	
 	// basic
-	public String id, chamber, vote_type, roll_type;
-	public String question, result, bill_id, required;
-	public int congress, number, year;
-	public Date voted_at;
-	public Map<String,Integer> voteBreakdown = new HashMap<String,Integer>();
-	
-	// bill
-	public Bill bill;
-	
-	// voters
+	public int congress, number, year, session;
+	public String id, chamber;
+    public String question, result, description, required;
+    public Date voted_at;
+
+    public Map<String,Integer> voteBreakdown = new HashMap<String,Integer>();
+
+    // if there was a tie breaker
+    public String tie_breaker, tie_breaker_vote;
+
+    // if a bill is associated
+    public String bill_id, bill_title;
+
+
+    // not yet migrated
 	public Map<String,Vote> voters;
-	
-	// voter_ids
 	public Map<String,Vote> voter_ids;
-	
-	// search result metadata (if coming from a search)
-	public SearchResult search;
 	
 	/**
 	 * Represents the vote of a legislator in a roll call. In almost all cases, votes will be 
@@ -59,9 +60,13 @@ public class Roll implements Serializable {
 		public Vote() {}
 		
 		public int compareTo(Vote another) {
-			return this.voter.compareTo(another.voter);
+            return this.voter_id.compareTo(another.voter_id);
 		}
 	}
+
+	public static String makeRollId(String chamber, int number, int year) {
+        return normalizeRollId(chamber, String.valueOf(number), String.valueOf(year));
+    }
 	
 	// splits a roll into chamber, number, and year, returned in a barebones Roll object
 	public static Roll splitRollId(String roll_id) {

--- a/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
@@ -208,7 +208,7 @@ public class BillService {
         return bill;
 	}
 
-	// TODO: remove once unused by RollService and UpcomingBillService
+	// TODO: remove once unused by UpcomingBillService
 	protected static Bill fromSunlightAPI(JSONObject json) throws JSONException, ParseException, CongressException {
 		Bill bill = new Bill();
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
@@ -1,5 +1,6 @@
 package com.sunlightlabs.congress.services;
 
+import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Roll;
 import com.sunlightlabs.congress.models.Roll.Vote;
@@ -9,6 +10,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -16,22 +18,43 @@ import java.util.List;
 import java.util.Map;
 
 public class RollService {
-	
+
+    public static String datetimeFormat = "yyyy-MM-dd hh:mm:ss";
+
+    // standard field names that map to Roll vote type names
+    public static final String YEA = "yes";
+    public static final String NAY = "no";
+    public static final String PRESENT = "present";
+    public static final String NOT_VOTING = "not_voting";
+
 	public static String[] basicFields = {
 		"roll_id", "chamber", "number", "year", "congress", "bill_id",
 		"bill.official_title", "bill.short_title",
 		"voted_at", "vote_type", "roll_type", "question", "required", "result",
 		"breakdown"
 	};
-	
-	public static Roll find(String id, String[] fields) throws CongressException {
-		Map<String,String> params = new HashMap<String,String>();
-		params.put("roll_id", id);
-		
-		return rollFor(Congress.url("votes", fields, params));
+
+    public static List<Roll> latestVotes(int page, int per_page) throws CongressException {
+        Map<String,String> params = new HashMap<String,String>();
+        params.put("order", "voted_at");
+        return sunlightRollsFor(Congress.url("votes", basicFields, params, page, per_page));
+    }
+
+    // /{congress}/{chamber}/sessions/{session-number}/votes/{roll-call-number}.json
+	public static Roll find(String id) throws CongressException {
+		Roll bare = Roll.splitRollId(id);
+        String chamber = bare.chamber;
+        String number = String.valueOf(bare.number);
+
+        int year = bare.year;
+        String congress = String.valueOf(Bill.congressForYear(year));
+        String session = String.valueOf(Bill.sessionForYear(year));
+
+        String[] endpoint = { congress, chamber, "sessions", session, "votes", number };
+		return rollFor(ProPublica.url(endpoint));
 	}
 	
-	public static List<Roll> latestVotes(String bioguideId, String chamber, int page, int per_page) throws CongressException {
+	public static List<Roll> latestMemberVotes(String bioguideId, String chamber, int page, int per_page) throws CongressException {
 		Map<String,String> params = new HashMap<String,String>();
 		params.put("order", "voted_at");
 		params.put("chamber", chamber);
@@ -41,19 +64,95 @@ public class RollService {
 		System.arraycopy(basicFields, 0, fields, 0, basicFields.length);
 		fields[basicFields.length + 0] = "voter_ids." + bioguideId;
 
-		return rollsFor(Congress.url("votes", fields, params, page, per_page)); 
+		return sunlightRollsFor(Congress.url("votes", fields, params, page, per_page));
 	}
-	
-	public static List<Roll> latestVotes(int page, int per_page) throws CongressException {
-		Map<String,String> params = new HashMap<String,String>();
-		params.put("order", "voted_at");
-		return rollsFor(Congress.url("votes", basicFields, params, page, per_page));
-	}
-	
-	
-	/* JSON parsers, also useful for other service endpoints within this package */
-	
-	protected static Roll fromAPI(JSONObject json) throws JSONException, ParseException, CongressException {
+
+	protected static Roll fromAPI(JSONObject json) throws JSONException, ParseException {
+        Roll roll = new Roll();
+
+        if (!json.isNull("congress"))
+            roll.congress = Integer.valueOf(json.getString("congress"));
+        if (!json.isNull("chamber"))
+            roll.chamber = json.getString("chamber").toLowerCase();
+        if (!json.isNull("roll_call"))
+            roll.number = Integer.valueOf(json.getString("roll_call"));
+        if (!json.isNull("session"))
+            roll.session = Integer.valueOf(json.getString("session"));
+
+        roll.id = Roll.makeRollId(roll.chamber, roll.number, roll.session);
+
+        if (!json.isNull("question"))
+            roll.question = json.getString("question");
+        if (!json.isNull("result"))
+            roll.result = json.getString("result");
+        if (!json.isNull("description"))
+            roll.description = json.getString("description");
+        if (!json.isNull("vote_type"))
+            roll.required = json.getString("vote_type");
+
+        // date and time fields make up a timestamp in Congress' time
+        if (!json.isNull("date") && !json.isNull("time")) {
+            String timestamp = json.getString("date") + " " + json.getString("time");
+            SimpleDateFormat format = new SimpleDateFormat(datetimeFormat);
+            format.setTimeZone(ProPublica.CONGRESS_TIMEZONE);
+            roll.voted_at = format.parse(timestamp);
+        }
+
+        // for now, not making use of latest_action
+        if (!json.isNull("bill")) {
+            JSONObject bill = json.getJSONObject("bill");
+            roll.bill_id = bill.getString("bill_id");
+            roll.bill_title = bill.getString("title");
+        }
+
+        roll.voteBreakdown.put(Roll.YEA, 0);
+        roll.voteBreakdown.put(Roll.NAY, 0);
+        roll.voteBreakdown.put(Roll.PRESENT, 0);
+        roll.voteBreakdown.put(Roll.NOT_VOTING, 0);
+
+        if (!json.isNull("total")) {
+            JSONObject total = json.getJSONObject("total");
+
+            // map yes/no/present/not_voting to Yea/Nay/Present/Not Voting
+            // but let Speaker votes go right through,
+            // and mark the roll call as having non-standard votes
+            Iterator<?> iter = total.keys();
+            while (iter.hasNext()) {
+                String key = (String) iter.next();
+
+                if (key.equals(RollService.YEA))
+                    roll.voteBreakdown.put(Roll.YEA, total.getInt(key));
+                else if (key.equals(RollService.NAY))
+                    roll.voteBreakdown.put(Roll.NAY, total.getInt(key));
+                else if (key.equals(RollService.NOT_VOTING))
+                    roll.voteBreakdown.put(Roll.NOT_VOTING, total.getInt(key));
+                else if (key.equals(RollService.PRESENT))
+                    roll.voteBreakdown.put(Roll.PRESENT, total.getInt(key));
+                else {
+                    roll.voteBreakdown.put(key, total.getInt(key));
+                    roll.otherVotes = true;
+                }
+            }
+
+            // if we detected there was a Speaker vote, remove yes/no from the breakdown
+            if (roll.otherVotes) {
+                roll.voteBreakdown.remove(Roll.YEA);
+                roll.voteBreakdown.remove(Roll.NAY);
+            }
+        }
+
+        // if there was a tiebreaker vote
+        // API bug: these can be empty strings instead of null
+        if (!json.isNull("tie_breaker") && !json.getString("tie_breaker").equals(""))
+            roll.tie_breaker = json.getString("tie_breaker");
+        if (!json.isNull("tie_breaker_vote") && !json.getString("tie_breaker_vote").equals(""))
+            roll.tie_breaker_vote = json.getString("tie_breaker_vote");
+
+
+        return roll;
+    }
+
+	protected static Roll fromSunlightAPI(JSONObject json) throws JSONException, ParseException, CongressException {
 		if (json == null)
 			throw new CongressException("Error loading votes.");
 		
@@ -61,8 +160,6 @@ public class RollService {
 		
 		if (!json.isNull("chamber"))
 			roll.chamber = json.getString("chamber");
-		if (!json.isNull("vote_type"))
-			roll.vote_type = json.getString("vote_type");
 		if (!json.isNull("question"))
 			roll.question = json.getString("question");
 		if (!json.isNull("result"))
@@ -81,15 +178,10 @@ public class RollService {
 			roll.number = json.getInt("number");
 		if (!json.isNull("roll_id"))
 			roll.id = json.getString("roll_id");
-		if (!json.isNull("roll_type"))
-			roll.roll_type = json.getString("roll_type");
 		
 		
 		if (!json.isNull("bill_id"))
 			roll.bill_id = json.getString("bill_id");
-
-		if (!json.isNull("bill"))
-			roll.bill = BillService.fromSunlightAPI(json.getJSONObject("bill"));
 
 		roll.voteBreakdown.put(Roll.YEA, 0);
 		roll.voteBreakdown.put(Roll.NAY, 0);
@@ -107,8 +199,7 @@ public class RollService {
 				if (!key.equals(Roll.YEA) && !key.equals(Roll.NAY) && !key.equals(Roll.PRESENT) && !key.equals(Roll.NOT_VOTING))
 					roll.otherVotes = true;
 			}
-			
-			//todo: what does this mean 
+
 			// until this is fixed on the server
 			if (roll.otherVotes) {
 				roll.voteBreakdown.remove(Roll.YEA);
@@ -124,7 +215,7 @@ public class RollService {
 				String voter_id = (String) iter.next();
 				JSONObject voterObject = votersObject.getJSONObject(voter_id);
 				
-				Roll.Vote vote = voteFromAPI(voter_id, voterObject);
+				Roll.Vote vote = voteFromSunlightAPI(voter_id, voterObject);
 				
 				// if there was no voter info for some reason, don't add the vote
 				if (vote != null)
@@ -140,14 +231,14 @@ public class RollService {
 				String voter_id = (String) iter.next();
 				String vote_name = voterIdsObject.getString(voter_id);
 				
-				roll.voter_ids.put(voter_id, voteFromAPI(voter_id, vote_name));
+				roll.voter_ids.put(voter_id, voteFromSunlightAPI(voter_id, vote_name));
 			}
 		}
 
 		return roll;
 	}
 
-	protected static Vote voteFromAPI(String voter_id, JSONObject json) throws JSONException, CongressException {
+	protected static Vote voteFromSunlightAPI(String voter_id, JSONObject json) throws JSONException, CongressException {
 		Vote vote = new Vote();
 		vote.vote = json.getString("vote");
 		vote.voter_id = voter_id;
@@ -158,32 +249,22 @@ public class RollService {
 			return vote;
 	}
 	
-	protected static Vote voteFromAPI(String voter_id, String vote_name) throws JSONException, CongressException {
+	protected static Vote voteFromSunlightAPI(String voter_id, String vote_name) throws JSONException, CongressException {
 		Vote vote = new Vote();
 		vote.vote = vote_name;
 		vote.voter_id = voter_id;
 		return vote;
 	}
-	
-	
-	private static Roll rollFor(String url) throws CongressException {
-		try {
-			return fromAPI(Congress.firstResult(url));
-		} catch (JSONException e) {
-			throw new CongressException(e, "Problem parsing the JSON from " + url);
-		} catch (ParseException e) {
-			throw new CongressException(e, "Problem parsing a date in the JSON from " + url);
-		}
-	}
-	
-	private static List<Roll> rollsFor(String url) throws CongressException {
+
+    // TODO: delete after migration
+	private static List<Roll> sunlightRollsFor(String url) throws CongressException {
 		List<Roll> rolls = new ArrayList<Roll>();
 		try {
 			JSONArray results = Congress.resultsFor(url);
 
 			int length = results.length();
 			for (int i = 0; i < length; i++)
-				rolls.add(fromAPI(results.getJSONObject(i)));
+				rolls.add(fromSunlightAPI(results.getJSONObject(i)));
 			
 		} catch (JSONException e) {
 			throw new CongressException(e, "Problem parsing the JSON from " + url);
@@ -191,6 +272,60 @@ public class RollService {
 			throw new CongressException(e, "Problem parsing a date in the JSON from " + url);
 		}
 		
+		return rolls;
+	}
+
+	// needs to do its own fetching, as the PP API uses an inconsistent
+    // type for the 'results' field on the vote-fetching endpoint
+    private static Roll rollFor(String url) throws CongressException {
+        try {
+            String rawJSON = ProPublica.fetchJSON(url);
+            JSONObject response = new JSONObject(rawJSON);
+
+            // First check that the Pro Publica API said 'OK'
+            String status = response.getString("status");
+            if (!status.equals("OK"))
+                throw new CongressException("Got a non-OK status from " + url + "\n\n" + rawJSON);
+
+            JSONObject voteObject = response.getJSONObject("results")
+                    .getJSONObject("votes")
+                    .getJSONObject("vote");
+
+            return fromAPI(voteObject);
+        } catch (JSONException e) {
+            throw new CongressException(e, "Problem parsing the JSON from " + url);
+        } catch (ParseException e) {
+            throw new CongressException(e, "Problem parsing a date in the JSON from " + url);
+        }
+    }
+
+    // Custom parsing method for votes by date
+	private static List<Roll> rollsFor(String url) throws CongressException {
+		List<Roll> rolls = new ArrayList<Roll>();
+        try {
+            String rawJSON = ProPublica.fetchJSON(url);
+            JSONObject response = new JSONObject(rawJSON);
+
+            // First check that the Pro Publica API said 'OK'
+            String status = response.getString("status");
+            if (!status.equals("OK"))
+                throw new CongressException("Got a non-OK status from " + url + "\n\n" + rawJSON);
+
+            JSONArray voteObjects = response.getJSONObject("results")
+                    .getJSONArray("votes");
+
+            for (int i=0; i<voteObjects.length(); i++) {
+                JSONObject vote = voteObjects.getJSONObject(i);
+                Roll roll = fromAPI(vote);
+                rolls.add(roll);
+            }
+
+        } catch (JSONException e) {
+            throw new CongressException(e, "Problem parsing the JSON from " + url);
+        } catch (ParseException e) {
+            throw new CongressException(e, "Problem parsing a date in the JSON from " + url);
+        }
+
 		return rolls;
 	}
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
@@ -2,6 +2,7 @@ package com.sunlightlabs.congress.services;
 
 import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.CongressException;
+import com.sunlightlabs.congress.models.Legislator;
 import com.sunlightlabs.congress.models.Roll;
 import com.sunlightlabs.congress.models.Roll.Vote;
 
@@ -195,6 +196,23 @@ public class RollService {
 
                 Roll.Vote vote = new Roll.Vote();
                 vote.voter_id = voter_id;
+
+                Legislator legislator = new Legislator();
+
+                if (!position.isNull("name")) {
+                    String[] names = Legislator.splitName(position.getString("name"));
+                    legislator.first_name = names[0];
+                    legislator.last_name = names[1];
+                }
+                if (!position.isNull("party"))
+                    legislator.party = position.getString("party");
+                if (!position.isNull("state"))
+                    legislator.state = position.getString("state");
+                if (!position.isNull("district"))
+                    legislator.district = position.getString("district");
+
+                vote.voter = legislator;
+
                 if (vote_position.equals(RollService.YEA))
                     vote.vote = Roll.YEA;
                 else if (vote_position.equals(RollService.NAY))

--- a/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
@@ -118,7 +118,7 @@ public class RollService {
                 else if (vote_type.equals(RollService.VOTE_TWO_THIRDS))
                     roll.required = "2/3";
                 else // can be QUORUM, pass it through
-                    roll.required = vote_type; 
+                    roll.required = vote_type;
             }
         }
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
@@ -117,8 +117,8 @@ public class RollService {
                     roll.required = "1/2";
                 else if (vote_type.equals(RollService.VOTE_TWO_THIRDS))
                     roll.required = "2/3";
-                else
-                    roll.required = vote_type; // shrug!
+                else // can be QUORUM, pass it through
+                    roll.required = vote_type; 
             }
         }
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
@@ -117,6 +117,8 @@ public class RollService {
                     roll.required = "1/2";
                 else if (vote_type.equals(RollService.VOTE_TWO_THIRDS))
                     roll.required = "2/3";
+                else
+                    roll.required = vote_type; // shrug!
             }
         }
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/RollService.java
@@ -36,7 +36,14 @@ public class RollService {
     // Pro Publica API uses "Speaker" to represent Speaker not voting
     public static final String SPEAKER = "Speaker";
 
-	public static String[] basicFields = {
+    // Pro Publica API uses these to denote certain House vote types
+    public static final String VOTE_HALF_ONE = "YEA-AND-NAY";
+    public static final String VOTE_HALF_TWO = "RECORDED VOTE";
+    public static final String VOTE_TWO_THIRDS  = "2/3 YEA-AND-NAY";
+
+
+
+    public static String[] basicFields = {
 		"roll_id", "chamber", "number", "year", "congress", "bill_id",
 		"bill.official_title", "bill.short_title",
 		"voted_at", "vote_type", "roll_type", "question", "required", "result",
@@ -96,8 +103,22 @@ public class RollService {
             roll.result = json.getString("result");
         if (!json.isNull("description"))
             roll.description = json.getString("description");
-        if (!json.isNull("vote_type"))
-            roll.required = json.getString("vote_type");
+
+        // In the Senate, the vote_type is just the fraction (1/2, 3/5)
+        // In the House, it can be one of a few denotations.
+        if (!json.isNull("vote_type")) {
+            String vote_type = json.getString("vote_type");
+            if (roll.chamber.equals("senate"))
+                roll.required = vote_type;
+            else {
+                if (vote_type.equals(RollService.VOTE_HALF_ONE))
+                    roll.required = "1/2";
+                else if (vote_type.equals(RollService.VOTE_HALF_TWO))
+                    roll.required = "1/2";
+                else if (vote_type.equals(RollService.VOTE_TWO_THIRDS))
+                    roll.required = "2/3";
+            }
+        }
 
         // date and time fields make up a timestamp in Congress' time
         if (!json.isNull("date") && !json.isNull("time")) {

--- a/app/src/main/res/layout/roll_basic_1.xml
+++ b/app/src/main/res/layout/roll_basic_1.xml
@@ -19,6 +19,20 @@
 		android:text="On Passage As Amended of H R 4489 Daniel Pearl Freedom of the Press Act"
 		/>
 
+	<TextView android:id="@+id/description"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+
+		android:layout_marginTop="10dp"
+		android:paddingLeft="10dp"
+		android:paddingRight="10dp"
+
+		android:textSize="14sp"
+        android:lineSpacingExtra="2sp"
+
+		android:text="A bill to amend the Federal Food, Drug, and Cosmetic Act to revise and extend the user-fee programs for prescription drugs, medical devices, generic drugs, and biosimilar biological products, and for other purposes."
+		/>
+
     <LinearLayout android:id="@+id/details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
This doesn't completely migrate vote data to the Pro Publica API, but it's a lot -- it fully migrates the vote details screen and the parsing of roll call data from the PP API.

I've verified that this properly handles Speaker of the House votes (which is informatically anomalous, since votes are names and not Yea/Nay, but can still contain Not Voting and Present).

Remaining voting-related issues (for a future PR):

* Recent vote lists/notifications - one complication here is that the PP API doesn't support "recent votes" in a paginated way, but https://github.com/propublica/congress-api-docs/issues/111 suggests it may be on its way.
* Votes by member - one complication used to be that the PP API wouldn't list the `result` or `totals` on this endpoint, but https://github.com/propublica/congress-api-docs/issues/103 suggests that this has been fixed.
