### PR TITLE
Migrate committee information to the Pro Publica Congress API

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/CommitteeListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/CommitteeListFragment.java
@@ -25,6 +25,7 @@ import com.sunlightlabs.congress.models.Committee;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 import com.sunlightlabs.congress.services.CommitteeService;
+import com.sunlightlabs.congress.services.LegislatorService;
 
 public class CommitteeListFragment extends ListFragment {
 	public static final int CHAMBER = 1;
@@ -196,7 +197,7 @@ public class CommitteeListFragment extends ListFragment {
 		private List<Committee> forLegislator(String bioguideId) {
 			List<Committee> committees;
 			try {
-				committees = CommitteeService.forLegislator(bioguideId);
+				committees = LegislatorService.find(bioguideId).committees;
 			} catch (CongressException e) {
 				this.exception = new CongressException(e, "Error loading committees.");
 				return null;
@@ -244,7 +245,7 @@ public class CommitteeListFragment extends ListFragment {
 		private List<Committee> forChamber(String chamber) {
 			List<Committee> result = new ArrayList<Committee>();
 			try {
-				result = CommitteeService.getAll(chamber);
+				result = CommitteeService.forChamber(chamber);
 			} catch (CongressException e) {
 				Log.e(Utils.TAG, "There has been an exception while getting the committees for chamber "
 						+ chamber + ": " + e.getMessage());
@@ -257,7 +258,7 @@ public class CommitteeListFragment extends ListFragment {
 		private List<Committee> forCommittee(String committeeId) {
 			List<Committee> result = new ArrayList<Committee>();
 			try {
-				result = CommitteeService.getSubcommitteesFor(committeeId);
+				result = CommitteeService.find(committeeId).subcommittees;
 			} catch (CongressException e) {
 				Log.e(Utils.TAG, "There has been an exception while getting the subcommittees for  "
 						+ committeeId + ": " + e.getMessage());

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
@@ -142,7 +142,7 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 	}
 	
 	public void setupControls() {
-		((Button) getView().findViewById(R.id.refresh)).setOnClickListener(new View.OnClickListener() {
+		getView().findViewById(R.id.refresh).setOnClickListener(new View.OnClickListener() {
 			public void onClick(View v) {
 				refresh();
 			}
@@ -362,7 +362,10 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 					temp = LegislatorService.allByLastName(context.lastName);
 					break;
 				case SEARCH_COMMITTEE:
-					temp = CommitteeService.find(context.committee.id).members;
+					if (context.committee.subcommittee)
+					    temp = CommitteeService.find(context.committee.parent_committee_id, context.committee.id).members;
+                    else
+                        temp = CommitteeService.find(context.committee.id).members;
 					break;
 				case SEARCH_STATE:
 					temp = LegislatorService.allForState(context.state);

--- a/app/src/main/java/com/sunlightlabs/congress/models/Committee.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Committee.java
@@ -7,10 +7,14 @@ public class Committee implements Comparable<Committee>, Serializable {
 	private static final long serialVersionUID = 1L;
 
 	public String id, name, chamber;
+	public String url;
 	
 	public boolean subcommittee;
-	public String parent_committee_id; 
-	
+	public String parent_committee_id, parent_committee_name;
+
+    public List<Committee> subcommittees;
+
+    public Legislator chair;
 	public List<Legislator> members;
 	
 	public String toString() {
@@ -19,8 +23,7 @@ public class Committee implements Comparable<Committee>, Serializable {
 	
 	public static class Membership implements Serializable {
 		private static final long serialVersionUID = 1L;
-		
-		public Legislator member;
+
 		public String side, title;
 		public int rank;
 		

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -2,6 +2,7 @@ package com.sunlightlabs.congress.models;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 
 public class Legislator implements Comparable<Legislator>, Serializable {
 	private static final long serialVersionUID = 1L;
@@ -17,9 +18,11 @@ public class Legislator implements Comparable<Legislator>, Serializable {
     // Only used when in a cosponsor context
     public Date cosponsored_on;
 	
-	// this gets assigned onto the legislator, even though it's not set this way in the API,
-	// so that we can reuse legislator listing code to list committee memberships
+	// Set during committee membership parsing, with side/title/rank.
 	public Committee.Membership membership;
+
+    // Committees a legislator is a member of.
+	public List<Committee> committees;
 
     // TODO: replace first_name uses with display name function
 	public String getName() {
@@ -31,7 +34,9 @@ public class Legislator implements Comparable<Legislator>, Serializable {
         if (title == null) {
             // This will be wrong for Delegates and Resident Commissioners,
             // But I can live with that. In many contexts, we'll have the title.
-            if (chamber.equals("house"))
+			if (chamber == null)
+			    return getName();
+            else if (chamber.equals("house"))
                 return "Rep. " + getName();
             else if (chamber.equals("senate"))
                 return "Sen. " + getName();

--- a/app/src/main/java/com/sunlightlabs/congress/services/CommitteeService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/CommitteeService.java
@@ -1,117 +1,189 @@
 package com.sunlightlabs.congress.services;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import org.apache.http.impl.cookie.DateParseException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.sunlightlabs.congress.models.Bill;
 import com.sunlightlabs.congress.models.Committee;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 
 public class CommitteeService {
-	
-	public static String[] basicFields = new String[] {
-		"committee_id", "chamber", "name",
-		"parent_committee_id", "subcommittee"
-	};
-	
-	public static Committee find(String id) throws CongressException {
-		String[] fields = new String[] {
-			"committee_id", "chamber", "name",
-			"parent_committee_id", "subcommittee",
-			"members"
-		};
-		Map<String,String> params = new HashMap<String,String>();
-		params.put("committee_id", id);
-		return committeeFor(Congress.url("committees", fields, params));
+
+    // /{congress}/{chamber}/committees/{committee_id}.json
+	public static Committee find(String committee_id) throws CongressException {
+        String chamber;
+        if (committee_id.toLowerCase().startsWith("h"))
+            chamber = "house";
+        else if (committee_id.toLowerCase().startsWith("s"))
+            chamber = "senate";
+        else
+            chamber = "joint";
+
+        String congress = String.valueOf(Bill.currentCongress());
+
+        String[] endpoint = { congress, chamber, "committees", committee_id };
+		return committeeFor(ProPublica.url(endpoint));
 	}
 
-	public static List<Committee> forLegislator(String bioguideId) throws CongressException {
-		Map<String,String> params = new HashMap<String,String>();
-		params.put("member_ids", bioguideId);
-		return committeesFor(Congress.url("committees", basicFields, params, 1, Congress.MAX_PER_PAGE));
+    // /{congress}/{chamber}/committees.json
+	public static List<Committee> forChamber(String chamber) throws CongressException {
+		String congress = String.valueOf(Bill.currentCongress());
+        String[] endpoint = { congress, chamber, "committees" };
+		return committeesFor(ProPublica.url(endpoint));
 	}
-	
-	public static List<Committee> getSubcommitteesFor(String committeeId) throws CongressException {
-		Map<String,String> params = new HashMap<String,String>();
-		params.put("subcommittee", "true");
-		params.put("parent_committee_id", committeeId);
-		return committeesFor(Congress.url("committees", basicFields, params, 1, Congress.MAX_PER_PAGE));
-	}
-	
-	public static List<Committee> getAll(String chamber) throws CongressException {
-		Map<String,String> params = new HashMap<String,String>();
-		params.put("chamber", chamber);
-		params.put("subcommittee", "false");
-		params.put("order", "name__asc");
-		return committeesFor(Congress.url("committees", basicFields, params, 1, Congress.MAX_PER_PAGE));
-	}
-	
-	protected static Committee fromAPI(JSONObject json) throws JSONException, CongressException {
-		Committee committee = new Committee();
-		
-		committee.id = json.getString("committee_id");
-		committee.name = json.getString("name");
-		committee.chamber = json.getString("chamber");
-		
-		if (!json.isNull("subcommittee"))
-			committee.subcommittee = json.getBoolean("subcommittee");
-		if (!json.isNull("parent_committee_id"))
-			committee.parent_committee_id = json.getString("parent_committee_id");
 
-		if (!json.isNull("members")) {
-			committee.members = new ArrayList<Legislator>();
-			
-			JSONArray memberList = json.getJSONArray("members");
-			for (int i = 0; i < memberList.length(); i++) {
-				JSONObject memberJson = memberList.getJSONObject(i);
-				Legislator legislator = LegislatorService.fromSunlight(memberJson.getJSONObject("legislator"));
-				
-				Committee.Membership membership = new Committee.Membership();
-				if (!memberJson.isNull("side"))
-					membership.side = memberJson.getString("side");
-				if (!memberJson.isNull("rank"))
-					membership.rank = memberJson.getInt("rank");
-				if (!memberJson.isNull("title"))
-					membership.title = memberJson.getString("title");
-				
-				legislator.membership = membership;
-						
-				committee.members.add(legislator);
-			}
-		}
-		
-		return committee;
-	}
-	
+	protected static Committee fromAPI(JSONObject json) throws JSONException, DateParseException, CongressException {
+        Committee committee = new Committee();
+
+        if (!json.isNull("id"))
+            committee.id = json.getString("id");
+
+        // is a subcommittee if it has a parent committee name/id
+        if (!json.isNull("committee_name")) {
+            committee.parent_committee_name = json.getString("committee_name");
+            // TODO: parent committee ID (for now, do it in calling method)
+            // committee.parent_committee_id = ___;
+            committee.subcommittee = true;
+        }
+
+        if (!json.isNull("chamber"))
+            committee.chamber = json.getString("chamber").toLowerCase();
+
+        if (!json.isNull("name")) {
+            committee.name = json.getString("name");
+
+            // If we can/should, prefix committee name with chamber
+            if (committee.chamber.equals("house"))
+                committee.name = "House " + committee.name;
+            else if (committee.chamber.equals("senate"))
+                committee.name = "Senate " + committee.name;
+        }
+
+        if (!json.isNull("url"))
+            committee.url = json.getString("url");
+
+        if (!json.isNull("chair_id")) {
+            Legislator chair = new Legislator();
+            chair.bioguide_id = json.getString("chair_id");
+
+            if (!json.isNull("chair")) {
+                String[] names = Legislator.splitName(json.getString("chair"));
+                chair.first_name = names[0];
+                chair.last_name = names[1];
+            }
+            if (!json.isNull("chair_party"))
+                chair.party = json.getString("chair_party");
+            if (!json.isNull("chair_state"))
+                chair.state = json.getString("chair_state");
+
+            committee.chair = chair;
+        }
+
+        if (!json.isNull("subcommittees")) {
+            JSONArray array = json.getJSONArray("subcommittees");
+            List<Committee> subcommittees = new ArrayList<Committee>();
+
+            for (int i=0; i<array.length(); i++) {
+                Committee subcommittee = new Committee();
+                subcommittee.parent_committee_id = committee.id;
+                subcommittee.subcommittee = true;
+
+                JSONObject object = array.getJSONObject(i);
+                subcommittee.id = object.getString("id");
+                subcommittee.name = object.getString("name");
+
+                subcommittees.add(subcommittee);
+            }
+
+            committee.subcommittees = subcommittees;
+        }
+
+        // details endpoint only
+        if (!json.isNull("current_members")) {
+            String chair_id = json.getString("chair_id");
+            String ranking_id = json.getString("ranking_member_id");
+
+            List<Legislator> members = new ArrayList<Legislator>();
+            JSONArray array = json.getJSONArray("current_members");
+
+            for (int i=0; i<array.length(); i++) {
+                JSONObject object = array.getJSONObject(i);
+                Legislator member = new Legislator();
+
+                if (!object.isNull("id"))
+                    member.bioguide_id = object.getString("id");
+                if (!object.isNull("party"))
+                    member.party = object.getString("party");
+                if (!object.isNull("state"))
+                    member.state = object.getString("state");
+                if (!object.isNull("name")) {
+                    String[] names = Legislator.splitName(object.getString("name"));
+                    member.first_name = names[0];
+                    member.last_name = names[1];
+                }
+
+                member.membership = new Committee.Membership();
+                // TODO: rank should really be absolute, not in party
+                // TODO: side and title, hopefully
+                if (!object.isNull("rank_in_party"))
+                    member.membership.rank = Integer.valueOf(object.getString("rank_in_party"));
+                else
+                    member.membership.rank = Integer.MIN_VALUE; // issue #141
+                member.membership.side = object.getString("side");
+
+                // There's no title field, but if their bioguide matches, set them here
+                if ((member.bioguide_id != null) && member.bioguide_id.equals(chair_id))
+                    member.membership.title = "Chair";
+                if ((member.bioguide_id != null) && member.bioguide_id.equals(ranking_id))
+                    member.membership.title = "Ranking Member";
+
+                members.add(member);
+            }
+            committee.members = members;
+        }
+
+        return committee;
+    }
 	
 	private static Committee committeeFor(String url) throws CongressException {
-		try {
-			return fromAPI(Congress.firstResult(url));
-		} catch (JSONException e) {
-			throw new CongressException(e, "Problem parsing the JSON from " + url);
-		}
-	}
+        try {
+            JSONArray results = ProPublica.resultsFor(url);
+            return fromAPI(results.getJSONObject(0));
+        } catch (JSONException e) {
+            throw new CongressException(e, "Problem parsing the JSON from " + url);
+        } catch (DateParseException e) {
+            throw new CongressException(e, "Problem parsing date in JSON at " + url);
+        }
+    }
 
-	private static List<Committee> committeesFor(String url) throws CongressException {
-		List<Committee> committees = new ArrayList<Committee>();
-		try {
-			JSONArray results = Congress.resultsFor(url);
+    private static List<Committee> committeesFor(String url) throws CongressException {
+        List<Committee> committees = new ArrayList<Committee>();
+        try {
+            JSONArray results = ProPublica.resultsFor(url);
 
-			int length = results.length();
-			for (int i = 0; i < length; i++)
-				committees.add(fromAPI(results.getJSONObject(i)));
+            if (results.length() > 0) {
+                JSONObject firstResult = results.getJSONObject(0);
+                if (!firstResult.isNull("committees"))
+                    results = firstResult.getJSONArray("committees");
+            }
 
-		} catch (JSONException e) {
-			throw new CongressException(e, "Problem parsing the JSON from " + url);
-		}
+            int length = results.length();
+            for (int i = 0; i < length; i++)
+                committees.add(fromAPI(results.getJSONObject(i)));
 
-		return committees;
-	}
+        } catch (JSONException e) {
+            throw new CongressException(e, "Problem parsing the JSON from " + url);
+        } catch (DateParseException e) {
+            throw new CongressException(e, "Problem parsing date in JSON at " + url);
+        }
+
+        return committees;
+    }
 
 }

--- a/app/src/main/java/com/sunlightlabs/congress/services/CommitteeService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/CommitteeService.java
@@ -58,8 +58,6 @@ public class CommitteeService {
         // is a subcommittee if it has a parent committee name/id
         if (!json.isNull("committee_name")) {
             committee.parent_committee_name = json.getString("committee_name");
-            // TODO: parent committee ID (for now, do it in calling method)
-            // committee.parent_committee_id = ___;
             committee.subcommittee = true;
         }
 
@@ -147,8 +145,6 @@ public class CommitteeService {
                     member.chamber = committee.chamber;
 
                 member.membership = new Committee.Membership();
-                // TODO: rank should really be absolute, not in party
-                // TODO: side and title, hopefully
                 if (!object.isNull("rank_in_party"))
                     member.membership.rank = Integer.valueOf(object.getString("rank_in_party"));
                 else

--- a/app/src/main/java/com/sunlightlabs/congress/services/Congress.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/Congress.java
@@ -187,18 +187,6 @@ public class Congress {
 	    }
 	}
 
-	public static JSONObject firstResult(String url) throws CongressException {
-		JSONArray results = resultsFor(url);
-		if (results.length() > 0) {
-			try {
-				return (JSONObject) results.get(0);
-			} catch(JSONException e) {
-				throw new CongressException(e, "Error getting first result from " + url);
-			}
-		} else
-			return null;
-	}
-
 	public static JSONArray resultsFor(String url) throws CongressException {
 		String rawJSON = fetchJSON(url);
 		JSONArray results = null;
@@ -208,15 +196,5 @@ public class Congress {
 			throw new CongressException(e, "Problem parsing the JSON from " + url);
 		}
 		return results;
-	}
-
-	public static List<String> listFrom(JSONArray array) throws JSONException {
-		int length = array.length();
-		List<String> list = new ArrayList<String>(length);
-
-		for (int i=0; i<length; i++)
-			list.add(array.getString(i));
-
-		return list;
 	}
 }

--- a/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
@@ -188,29 +188,15 @@ public class LegislatorService {
             if (!role.isNull("phone"))
                 legislator.phone = role.getString("phone");
 
-            // committee memberships get stored on roles
-            if (!role.isNull("committees")) {
-                JSONArray list = role.getJSONArray("committees");
-                List<Committee> committees =new ArrayList<Committee>();
-                for (int i=0; i<list.length(); i++) {
-                    JSONObject object = list.getJSONObject(i);
-                    Committee committee = new Committee();
-                    committee.name = object.getString("name");
-                    committee.id = object.getString("code");
-                    // TODO: note whether it's a subcommittee or not based on ID?
-                    committee.subcommittee = false;
-                    // TODO: detect chamber from ID?
-                    if (committee.id.startsWith("H"))
-                        committee.chamber = "house";
-                    else if (committee.id.startsWith("S"))
-                        committee.chamber = "senate";
-                    else // if (committee.id.startsWith("J"))
-                        committee.chamber ="joint";
+            // committee memberships stored on roles, in separate fields
+            // the list of committees per-member will be sorted by committee ID
+            // so returning them as one big flat list will work
+            legislator.committees = new ArrayList<Committee>();
+            if (!role.isNull("committees"))
+                legislator.committees.addAll(CommitteeService.committeesFromArray(role.getJSONArray("committees"), false));
+            if (!role.isNull("subcommittees"))
+                legislator.committees.addAll(CommitteeService.committeesFromArray(role.getJSONArray("subcommittees"), true));
 
-                    committees.add(committee);
-                }
-                legislator.committees = committees;
-            }
         }
 
         // most minimal form: list of cosponsors, ID and name only

--- a/app/src/main/res/layout/committee_item.xml
+++ b/app/src/main/res/layout/committee_item.xml
@@ -7,6 +7,7 @@
 	android:paddingLeft="20dp"
 	android:paddingTop="12dp"
 	android:paddingBottom="12dp"
+	android:paddingRight="20dp"
 	
 	android:textSize="16sp"
 	

--- a/app/src/main/res/layout/committee_item_sub.xml
+++ b/app/src/main/res/layout/committee_item_sub.xml
@@ -7,6 +7,7 @@
 	android:paddingLeft="40dp"
 	android:paddingTop="12dp"
 	android:paddingBottom="12dp"
+	android:paddingRight="20dp"
 	
 	android:textSize="14sp"
 	android:textColor="@color/text_grey"


### PR DESCRIPTION
This moves the committee endpoints entirely over to the Pro Publica Congress API.

Some notes on changes in client behavior:

* We can't display the title (e.g. `Rep.`) of members of Congress on joint committees, as the legislator's chamber is not inferrable when looking at committee memberships for joint committees. (See: https://github.com/propublica/congress-api-docs/issues/140)
* We now don't have a way of showing `Vice Chairman` of some joint committees, and instead show a ranking member. (See: https://github.com/propublica/congress-api-docs/issues/142)
* We don't have any concept of Ex Oficio members or anything else other than chair and ranking member. Those are the fields standardized for all committees across the Pro Publica API.
* Senate subcommittees are missing, but it looks like this will be fixed server-side. (See: https://github.com/propublica/congress-api-docs/issues/144)
* Some committee ordering is out of whack, due to null rank fields on some joint committees. (See: https://github.com/propublica/congress-api-docs/issues/141)
* We no longer have two joint committees which only sort of operate as such, one on Europe and one on narcotics control. (See: https://github.com/propublica/congress-api-docs/issues/135, https://github.com/propublica/congress-api-docs/issues/138)
* We're relying on committee IDs being 4-character subsets of subcommittee IDs when parsing subcommittee memberships of individual members on their details endpoints. (See: https://github.com/propublica/congress-api-docs/issues/126)

Any changes or fixes for the above will happen server-side, so this is stable to ship from the client perspective.

@dwillis - CCing you in case you're interested in reviewing the client code.