### PR TITLE
Migrate voting lists to the Pro Publica Congress API

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -123,7 +123,7 @@ public class RollListFragment extends ListFragment implements PaginationListener
 		Subscription subscription = null;
 		
 		if (type == ROLLS_VOTER)
-			subscription = new Subscription(voter.bioguide_id, Subscriber.notificationName(voter), "RollsLegislatorSubscriber", null);
+			subscription = new Subscription(voter.bioguide_id, Subscriber.notificationName(voter), "RollsLegislatorSubscriber", voter.chamber);
 		else if (type == ROLLS_RECENT)
 			subscription = new Subscription("RecentVotes", "Recent Votes", "RollsRecentSubscriber", null);
 		

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -123,7 +123,7 @@ public class RollListFragment extends ListFragment implements PaginationListener
 		Subscription subscription = null;
 		
 		if (type == ROLLS_VOTER)
-			subscription = new Subscription(voter.bioguide_id, Subscriber.notificationName(voter), "RollsLegislatorSubscriber", voter.chamber);
+			subscription = new Subscription(voter.bioguide_id, Subscriber.notificationName(voter), "RollsLegislatorSubscriber", null);
 		else if (type == ROLLS_RECENT)
 			subscription = new Subscription("RecentVotes", "Recent Votes", "RollsRecentSubscriber", null);
 		
@@ -213,9 +213,9 @@ public class RollListFragment extends ListFragment implements PaginationListener
 				
 				switch (context.type) {
 				case ROLLS_VOTER:
-					return RollService.latestMemberVotes(context.voter.bioguide_id, context.voter.chamber, page, PER_PAGE);
+					return RollService.latestMemberVotes(context.voter.bioguide_id, page);
 				case ROLLS_RECENT:
-					return RollService.latestVotes(page, PER_PAGE);
+					return RollService.latestVotes(page);
 				default:
 					throw new CongressException("Not sure what type of votes to find.");
 				}
@@ -327,10 +327,6 @@ public class RollListFragment extends ListFragment implements PaginationListener
 		}
 		
 		private void shortDate(TextView view, Date date) {
-//			if (date.getYear() == Calendar.getInstance().get(Calendar.YEAR)) {
-//				view.setTextSize(18);
-//				view.setText(new SimpleDateFormat("MMM d", Locale.US).format(date).toUpperCase(Locale.US));
-//			} else
 			longDate(view, date);
 		}
 		

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -270,12 +270,13 @@ public class RollListFragment extends ListFragment implements PaginationListener
 				holder = (ViewHolder) view.getTag();
 			
 			TextView msgView = holder.roll;
+
+            // ?? why does this also activate for ROLLS_RECENT?
 			if (context.voter != null && (context.type == ROLLS_VOTER || context.type == ROLLS_RECENT)) {
-				Roll.Vote vote = roll.voter_ids.get(context.voter.bioguide_id);
-				if (vote == null || vote.vote.equals(Roll.NOT_VOTING))
-					msgView.setText("Did Not Vote");
+				if (roll.member_position == null || roll.member_position.equals(Roll.NOT_VOTING))
+					msgView.setText(R.string.votes_did_not_vote);
 				else
-					msgView.setText(vote.vote);
+					msgView.setText(roll.member_position);
 				
 			} else
 				msgView.setText(Utils.capitalize(roll.chamber));

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsLegislatorSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsLegislatorSubscriber.java
@@ -23,10 +23,9 @@ public class RollsLegislatorSubscriber extends Subscriber {
 	@Override
 	public List<?> fetchUpdates(Subscription subscription) {
 		Utils.setupAPI(context);
-		String chamber = subscription.data;
 		
 		try {
-			return RollService.latestMemberVotes(subscription.id, chamber, 1, RollListFragment.PER_PAGE);
+			return RollService.latestMemberVotes(subscription.id, 1);
 		} catch (CongressException e) {
 			Log.w(Utils.TAG, "Could not fetch the latest votes for " + subscription, e);
 			return null;

--- a/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsRecentSubscriber.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/notifications/subscribers/RollsRecentSubscriber.java
@@ -26,7 +26,7 @@ public class RollsRecentSubscriber extends Subscriber {
 		Utils.setupAPI(context);
 		
 		try {
-			return RollService.latestVotes(1, RollListFragment.PER_PAGE);
+			return RollService.latestVotes(1);
 		} catch (CongressException e) {
 			Log.w(Utils.TAG, "Could not fetch the latest votes for " + subscription, e);
 			return null;

--- a/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
@@ -116,6 +116,14 @@ public class Bill implements Serializable {
             return 2;
     }
 
+    public static int yearFrom(int congress, int session) {
+        // first year of that Congress
+        int base = (((congress + 894) * 2) - 1);
+
+        // if it's session 2, up it by 1 year
+        return base + (session - 1);
+    }
+
 	public static String formatCode(String bill_id) {
 		// [bill_type, number, congress]
         String[] pieces = splitBillId(bill_id);

--- a/app/src/main/java/com/sunlightlabs/congress/models/Roll.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Roll.java
@@ -33,7 +33,6 @@ public class Roll implements Serializable {
     // if a bill is associated
     public String bill_id, bill_title;
 
-
     // not yet migrated
 	public Map<String,Vote> voters;
 	public Map<String,Vote> voter_ids;
@@ -58,8 +57,9 @@ public class Roll implements Serializable {
 		public Legislator voter;
 		
 		public Vote() {}
-		
-		public int compareTo(Vote another) {
+
+        @Override
+        public int compareTo(Vote another) {
             return this.voter_id.compareTo(another.voter_id);
 		}
 	}
@@ -89,7 +89,7 @@ public class Roll implements Serializable {
 	
 	// formattedNumber can be anything that ends with a number - the number will be extracted,
 	// the chamber's first letter will be used, and combined into a roll ID
-	public static String normalizeRollId(String chamber, String year, String formattedNumber) {
+	public static String normalizeRollId(String chamber, String formattedNumber, String year) {
 		String shortChamber;
 		if (chamber.equals("house"))
 			shortChamber = "h";

--- a/app/src/main/java/com/sunlightlabs/congress/models/Roll.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Roll.java
@@ -33,9 +33,10 @@ public class Roll implements Serializable {
     // if a bill is associated
     public String bill_id, bill_title;
 
-    // not yet migrated
 	public Map<String,Vote> voters;
-	public Map<String,Vote> voter_ids;
+
+    // convenience field for when this is loaded for a specific member
+    public String member_position;
 	
 	/**
 	 * Represents the vote of a legislator in a roll call. In almost all cases, votes will be 

--- a/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/ProPublica.java
@@ -36,7 +36,6 @@ public class ProPublica {
 
     public static TimeZone CONGRESS_TIMEZONE = TimeZone.getTimeZone("America/New_York");
     public static String dateOnlyFormat = "yyyy-MM-dd";
-    public static String timeOnlyFormat = "hh:mm:ss";
 
 
     // Pro Publica Per Page

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="bills_empty_search_relevant">No bills found by that search.\n\nWhen searching by relevance, searching is limited to the current session of Congress.\n\nBills from previous sessions of Congress will not appear.</string>
     
     <string name="votes_empty_voter">No votes found by this person.</string>
+    <string name="votes_did_not_vote">Did Not Vote</string>
     
     <string name="new_result">NEW</string>
     


### PR DESCRIPTION
This completes the work begun in #717 by porting the two vote listing screens -- recent votes, and recent votes by a given member -- to the Pro Publica Congress API.

* There are some minor display changes/regressions around showing details of a vote inline -- the information about bills seems a little less nice compared to what it was.
* Despite the Pro Publica API using `Yes`, we continue to use `Yea` unchanged. Same for the other standard display values we were using.
* Member votes come back in a single page of 100 votes, with no pagination provided. However, a server-side fix for this is planned in https://github.com/propublica/congress-api-docs/issues/147, which should cause the app to begin processing it correctly without further client-side changes.