### PR TITLE
Fix to Legislator.shortTitle()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:1.3.0'
     compile 'com.squareup.picasso:picasso:2.2.0'
     compile 'com.google.android.gms:play-services:4.3.23'
+    testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -77,8 +77,10 @@ public class Legislator implements Comparable<Legislator>, Serializable {
 			return "Sen";
 		else if (longTitle.equals("Delegate"))
 			return "Del";
-		else if (longTitle.equals("Resident Commissioner"));
+		else if (longTitle.equals("Resident Commissioner"))
 			return "Com";
+
+		return "";
 	}
 
 	public String fullTitle() {

--- a/app/src/test/java/com/sunlightlabs/congress/models/LegislatorTest.java
+++ b/app/src/test/java/com/sunlightlabs/congress/models/LegislatorTest.java
@@ -1,0 +1,21 @@
+package com.sunlightlabs.congress.models;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LegislatorTest {
+
+    @Test
+    public void shortTitle() {
+        
+        assertEquals(Legislator.shortTitle("Representative"), "Rep");
+        assertEquals(Legislator.shortTitle("Senator"), "Sen");
+        assertEquals(Legislator.shortTitle("Delegate"), "Del");
+        assertEquals(Legislator.shortTitle("Resident Commissioner"), "Com");
+        assertEquals(Legislator.shortTitle(""), "");
+        assertEquals(Legislator.shortTitle("Justice"), "");
+
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 

--- a/congress-android.iml
+++ b/congress-android.iml
@@ -16,4 +16,8 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="sonarModuleSettings">
+    <option name="localAnalysisScripName" value="&lt;PROJECT&gt;" />
+    <option name="serverName" value="&lt;PROJECT&gt;" />
+  </component>
 </module>

--- a/congress-android.iml
+++ b/congress-android.iml
@@ -16,8 +16,4 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
-  <component name="sonarModuleSettings">
-    <option name="localAnalysisScripName" value="&lt;PROJECT&gt;" />
-    <option name="serverName" value="&lt;PROJECT&gt;" />
-  </component>
 </module>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jun 25 18:50:52 EDT 2017
+#Thu May 10 05:37:03 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Removed semicolon at the end of an if so that the proper abbreviation was returned from Legislator.shortTitle().

Also, updated Gradle versions based on security warnings by Android Studio.