### PR TITLE
Assorted code cleanups and fixes

### DIFF
--- a/app/src/main/java/com/sunlightlabs/android/congress/BillPager.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/BillPager.java
@@ -74,7 +74,7 @@ public class BillPager extends Activity implements HasActionMenu {
 		findViewById(R.id.pager_container).setVisibility(View.GONE);
 		Utils.setLoading(this, R.string.bill_loading);
 		
-		((Button) findViewById(R.id.refresh)).setOnClickListener(new View.OnClickListener() {
+		findViewById(R.id.refresh).setOnClickListener(new View.OnClickListener() {
 			public void onClick(View v) {
 				refresh();
 			}

--- a/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/RollInfo.java
@@ -124,9 +124,8 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 			this.currentTab = holder.currentTab;
 			
 			if (loadPhotoTasks != null) {
-				Iterator<LoadPhotoTask> iterator = loadPhotoTasks.values().iterator();
-				while (iterator.hasNext())
-					iterator.next().onScreenLoad(this);
+				for (LoadPhotoTask loadPhotoTask : loadPhotoTasks.values())
+					loadPhotoTask.onScreenLoad(this);
 			}
 		}
 		
@@ -265,9 +264,7 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 		View.OnClickListener tabListener = new View.OnClickListener() {
 			public void onClick(View view) {
 				String tag = (String) view.getTag();
-				Iterator<String> iter = voterBreakdown.keySet().iterator();
-				while (iter.hasNext()) {
-					String tabTag = iter.next();
+				for (String tabTag : voterBreakdown.keySet()) {
 					if (tabTag.equals(tag))
 						header.findViewWithTag(tabTag).setSelected(true);
 					else
@@ -353,11 +350,9 @@ public class RollInfo extends ListActivity implements LoadPhotoTask.LoadsPhoto {
 			// sort Map of voters into the voterBreakdown Map by vote type
 			List<Roll.Vote> allVoters = new ArrayList<Roll.Vote>(roll.voters.values());
 			Collections.sort(allVoters); // sort once, all at once
-			
-			Iterator<Roll.Vote> iter = allVoters.iterator();
-			while (iter.hasNext()) {
-				Roll.Vote vote = iter.next();
-                voterBreakdown.get(vote.vote).add(vote);
+
+			for (Vote vote : allVoters) {
+				voterBreakdown.get(vote.vote).add(vote);
 			}
 			
 			// hide loading, show tabs

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
@@ -86,7 +86,7 @@ public class FloorUpdateFragment extends ListFragment implements PaginationListe
 	}
 	
 	public void setupControls() {
-		((Button) getView().findViewById(R.id.refresh)).setOnClickListener(new View.OnClickListener() {
+		getView().findViewById(R.id.refresh).setOnClickListener(new View.OnClickListener() {
 			public void onClick(View v) {
 				refresh();
 			}

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/FloorUpdateFragment.java
@@ -63,9 +63,8 @@ public class FloorUpdateFragment extends ListFragment implements PaginationListe
 	
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		View main = inflater.inflate(R.layout.list_footer, container, false);
-		
-		return main;
+
+		return inflater.inflate(R.layout.list_footer, container, false);
 	}
 	
 	@Override

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/LegislatorListFragment.java
@@ -333,8 +333,13 @@ public class LegislatorListFragment extends ListFragment implements LoadPhotoTas
 			
 			@Override
 			public boolean equals(Object holder) {
+
+				if (!(holder instanceof ViewHolder)) {
+					return false;
+				}
 				ViewHolder other = (ViewHolder) holder;
-				return other != null && other instanceof ViewHolder && this.bioguide_id.equals(other.bioguide_id);
+
+				return this.bioguide_id.equals(other.bioguide_id);
 			}
 		}
 

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -103,7 +103,7 @@ public class RollListFragment extends ListFragment implements PaginationListener
 	}
 	
 	public void setupControls() {
-		((Button) getView().findViewById(R.id.refresh)).setOnClickListener(new View.OnClickListener() {
+		getView().findViewById(R.id.refresh).setOnClickListener(new View.OnClickListener() {
 			public void onClick(View v) {
 				refresh();
 			}

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -309,19 +309,19 @@ public class RollListFragment extends ListFragment implements PaginationListener
 		}
 		
 		private String resultFor(Roll roll) {
-			String breakdown;
+			StringBuilder breakdown;
 			if (roll.otherVotes) {
-				breakdown = "";
+				breakdown = new StringBuilder();
 				Iterator<Integer> iter = roll.voteBreakdown.values().iterator();
 				while (iter.hasNext()) {
-					breakdown += iter.next();
+					breakdown.append(iter.next());
 					if (iter.hasNext())
-						breakdown += "-";
+						breakdown.append("-");
 				}
 			} else {
-				breakdown = roll.voteBreakdown.get(Roll.YEA)+ "-" + roll.voteBreakdown.get(Roll.NAY);
+				breakdown = new StringBuilder(roll.voteBreakdown.get(Roll.YEA) + "-" + roll.voteBreakdown.get(Roll.NAY));
 				if (roll.voteBreakdown.get(Roll.PRESENT) > 0)
-					breakdown += "-" + roll.voteBreakdown.get(Roll.PRESENT);
+					breakdown.append("-").append(roll.voteBreakdown.get(Roll.PRESENT));
 			}
 			
 			return roll.result + ", " + breakdown;

--- a/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/fragments/RollListFragment.java
@@ -324,7 +324,7 @@ public class RollListFragment extends ListFragment implements PaginationListener
 					breakdown += "-" + roll.voteBreakdown.get(Roll.PRESENT);
 			}
 			
-			return roll.result + ", " + breakdown.toString();
+			return roll.result + ", " + breakdown;
 		}
 		
 		private void shortDate(TextView view, Date date) {

--- a/app/src/main/java/com/sunlightlabs/android/congress/tasks/LoadPhotoTask.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/tasks/LoadPhotoTask.java
@@ -39,7 +39,7 @@ public class LoadPhotoTask extends AsyncTask<String,Void,Drawable> {
 	}
 	
 	public interface LoadsPhoto {
-		public void onLoadPhoto(Drawable photo, Object tag);
-		public Context getContext();
+		void onLoadPhoto(Drawable photo, Object tag);
+		Context getContext();
 	}
 }

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Database.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Database.java
@@ -251,7 +251,7 @@ public class Database {
 			StringBuilder sql = new StringBuilder("CREATE TABLE " + table);
 			sql.append(" (_id INTEGER PRIMARY KEY AUTOINCREMENT");
 
-			for (String column : columns) sql.append(", " + column + " TEXT");
+			for (String column : columns) sql.append(", ").append(column).append(" TEXT");
 
 			sql.append(");");
 			db.execSQL(sql.toString());

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Database.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Database.java
@@ -71,8 +71,7 @@ public class Database {
 		try {
 			Class<?> cls = Class.forName("com.sunlightlabs.congress.models.Legislator");
 			ContentValues cv = new ContentValues(size);
-			for (int i = 0; i < LEGISLATOR_COLUMNS.length; i++) {
-				String column = LEGISLATOR_COLUMNS[i];
+			for (String column : LEGISLATOR_COLUMNS) {
 				cv.put(column, (String) cls.getDeclaredField(column).get(legislator));
 			}
 			return cv;
@@ -130,8 +129,7 @@ public class Database {
 		try {
 			Class<?> cls = Class.forName("com.sunlightlabs.congress.models.Bill");
 			ContentValues cv = new ContentValues(BILL_COLUMNS.length);
-			for (int i = 0; i < BILL_COLUMNS.length; i++) {
-				String column = BILL_COLUMNS[i];
+			for (String column : BILL_COLUMNS) {
 				cv.put(column, (String) cls.getDeclaredField(column).get(bill));
 			}
 			return database.insert("bills", null, cv);
@@ -253,8 +251,7 @@ public class Database {
 			StringBuilder sql = new StringBuilder("CREATE TABLE " + table);
 			sql.append(" (_id INTEGER PRIMARY KEY AUTOINCREMENT");
 
-			for (int i = 0; i < columns.length; i++)
-				sql.append(", " + columns[i] + " TEXT");
+			for (String column : columns) sql.append(", " + column + " TEXT");
 
 			sql.append(");");
 			db.execSQL(sql.toString());
@@ -442,56 +439,54 @@ public class Database {
 					
 					
 					String[] subscriptions = new String[] {"ActionsBillSubscriber", "VotesBillSubscriber", "NewsBillSubscriber"};
-					for (int i=0; i<subscriptions.length; i++) {
-						String subscription = subscriptions[i];
+					for (String subscription : subscriptions) {
 						rows = 0;
-						
+
 						Log.i(Utils.TAG, "- In subscriptions table (" + subscription + ")...");
-						cursor = db.rawQuery("SELECT * FROM subscriptions WHERE notification_class = ? AND id LIKE \"%cres%\"", new String[] { subscription });
+						cursor = db.rawQuery("SELECT * FROM subscriptions WHERE notification_class = ? AND id LIKE \"%cres%\"", new String[]{subscription});
 						if (cursor.moveToFirst()) {
 							do {
 								String billId = cursor.getString(cursor.getColumnIndexOrThrow("id"));
 								if (billId.contains("cres")) {
-									
+
 									String newId = billId.replace("cres", "conres");
 									String newData = newId;
-									
+
 									// bill news subscriptions use the formatted code as the data
 									if (subscription.equals("NewsBillSubscriber")) {
 										String billCode = cursor.getString(cursor.getColumnIndexOrThrow("data"));
 										newData = billCode.replace("C. Res.", "Con. Res.");
 									}
-									
+
 									Log.i(Utils.TAG, "    [" + billId + "] -> [" + newId + "]");
-									db.execSQL("UPDATE subscriptions SET id=?, data=? WHERE id=? AND notification_class=?", new String[] {newId, newData, billId, subscription});
+									db.execSQL("UPDATE subscriptions SET id=?, data=? WHERE id=? AND notification_class=?", new String[]{newId, newData, billId, subscription});
 									rows += 1;
 								}
 							} while (cursor.moveToNext());
 						}
-						
+
 						Log.i(Utils.TAG, "Updated " + rows + " subscriptions rows with new ids (" + subscription + ")");
 					}
 					
 					String[] seenTypes = new String[] { "BillsLawsSubscriber", "BillsLegislatorSubscriber", "BillsRecentSubscriber", "BillsSearchSubscriber" };
-					for (int i=0; i<seenTypes.length; i++) {
-						String seenType = seenTypes[i];
+					for (String seenType : seenTypes) {
 						rows = 0;
-						
+
 						Log.i(Utils.TAG, "- In seen_items table (" + seenType + ")...");
-						cursor = db.rawQuery("SELECT * FROM seen_items WHERE subscription_class = ? AND seen_id LIKE \"%cres%\"", new String[] { seenType});
+						cursor = db.rawQuery("SELECT * FROM seen_items WHERE subscription_class = ? AND seen_id LIKE \"%cres%\"", new String[]{seenType});
 						if (cursor.moveToFirst()) {
 							do {
 								String billId = cursor.getString(cursor.getColumnIndexOrThrow("seen_id"));
 								if (billId.contains("cres")) {
 									String newId = billId.replace("cres", "conres");
-									
+
 									Log.i(Utils.TAG, "    [" + billId + "] -> [" + newId + "]");
-									db.execSQL("UPDATE seen_items SET seen_id=? WHERE seen_id=? and subscription_class=?", new String[] {newId, billId, seenType});
+									db.execSQL("UPDATE seen_items SET seen_id=? WHERE seen_id=? and subscription_class=?", new String[]{newId, billId, seenType});
 									rows += 1;
 								}
 							} while (cursor.moveToNext());
 						}
-						
+
 						Log.i(Utils.TAG, "Updated " + rows + " seen_items rows with new ids (" + seenType + ")");
 					}
 					

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/PaginationListener.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/PaginationListener.java
@@ -6,7 +6,7 @@ import android.widget.AbsListView.OnScrollListener;
 public class PaginationListener implements OnScrollListener {
 	
 	public interface Paginates {
-		public void loadNextPage(int page);
+		void loadNextPage(int page);
 	}
 	
 	private Paginates context;

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/TitlePageAdapter.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/TitlePageAdapter.java
@@ -131,8 +131,8 @@ public class TitlePageAdapter extends FragmentPagerAdapter {
     	titleViews.get(handle).findViewById(R.id.tab_line).setVisibility(View.VISIBLE);
     }
     
-    public static interface SelectedOnce {
-    	public void onSelectedOnce();
+    public interface SelectedOnce {
+    	void onSelectedOnce();
     }
     
     private static class TitlePageListener extends ViewPager.SimpleOnPageChangeListener {

--- a/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Bill.java
@@ -74,10 +74,7 @@ public class Bill implements Serializable {
 		public boolean passed() {
 			if (this.result == null) return false;
 
-            Pattern pattern = Pattern.compile("passed", Pattern.CASE_INSENSITIVE);
-            Matcher matcher = pattern.matcher(this.result);
-            boolean passed = matcher.find();
-            return passed;
+            		return Pattern.compile("passed", Pattern.CASE_INSENSITIVE).matcher(this.result).find();
 		}
 	}
 	
@@ -133,14 +130,13 @@ public class Bill implements Serializable {
 
 	// returns [bill_type, number, congress]
 	public static String[] splitBillId(String bill_id) {
-        Pattern pattern = Pattern.compile("^([a-z]+)(\\d+)-(\\d+)$");
-        Matcher matcher = pattern.matcher(bill_id);
-        if (!matcher.find())
-            return null;
+		Pattern pattern = Pattern.compile("^([a-z]+)(\\d+)-(\\d+)$");
+		Matcher matcher = pattern.matcher(bill_id);
+        	if (!matcher.find())
+			return null;
 
-        String[] pieces = { matcher.group(1), matcher.group(2), matcher.group(3) };
-        return pieces;
-    }
+        	return new String[]{ matcher.group(1), matcher.group(2), matcher.group(3) };
+	}
 
     // also expanded to handle amendment IDs
 	public static String formatCode(String bill_type, int number) {

--- a/app/src/main/java/com/sunlightlabs/congress/models/Committee.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Committee.java
@@ -27,8 +27,8 @@ public class Committee implements Comparable<Committee>, Serializable {
 		public String side, title;
 		public int rank;
 		
-		public Membership() {};
-	}
+		public Membership() {}
+    }
 	
 	public int compareTo(Committee another) {
 		String mine = name.replace("the ", "");

--- a/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
+++ b/app/src/main/java/com/sunlightlabs/congress/models/Legislator.java
@@ -64,8 +64,7 @@ public class Legislator implements Comparable<Legislator>, Serializable {
 			last_name = pieces[pieces.length-2] + " " + pieces[pieces.length-1];
 
 
-		String[] names = {first_name, last_name};
-		return names;
+		return new String[]{first_name, last_name};
 	}
 
 	// Used to parse long titles from Pro Publica API

--- a/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
@@ -72,7 +72,7 @@ public class BillService {
 		return billFor(ProPublica.url(endpoint));
 	}
 
-	protected static Bill fromAPI(JSONObject json) throws JSONException, ParseException, CongressException {
+	protected static Bill fromAPI(JSONObject json) throws JSONException, ParseException {
 		Bill bill = new Bill();
 
         // Fail if this isn't present.

--- a/app/src/main/java/com/sunlightlabs/congress/services/CommitteeService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/CommitteeService.java
@@ -48,7 +48,7 @@ public class CommitteeService {
 		return committeesFor(ProPublica.url(endpoint));
 	}
 
-	protected static Committee fromAPI(JSONObject json) throws JSONException, CongressException {
+	protected static Committee fromAPI(JSONObject json) throws JSONException {
         Committee committee = new Committee();
 
         if (!json.isNull("id"))

--- a/app/src/main/java/com/sunlightlabs/congress/services/FloorUpdateService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/FloorUpdateService.java
@@ -27,7 +27,7 @@ public class FloorUpdateService {
         return updates;
 	}
 	
-	protected static FloorUpdate fromAPI(JSONObject json) throws JSONException, ParseException, CongressException {
+	protected static FloorUpdate fromAPI(JSONObject json) throws JSONException, ParseException {
 		FloorUpdate update = new FloorUpdate();
 
         if (!json.isNull("description"))

--- a/app/src/main/java/com/sunlightlabs/congress/services/FloorUpdateService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/FloorUpdateService.java
@@ -20,11 +20,9 @@ public class FloorUpdateService {
 	// /{congress}/{chamber}/floor_updates.json
 	public static List<FloorUpdate> latest(String chamber, int page) throws CongressException {
 		String congress = String.valueOf(Bill.currentCongress());
-        String[] endpoint = { congress, chamber, "floor_updates" };
-		
-		List<FloorUpdate> updates = updatesFor(ProPublica.url(endpoint, page));
+		String[] endpoint = { congress, chamber, "floor_updates" };
 
-        return updates;
+		return updatesFor(ProPublica.url(endpoint, page));
 	}
 	
 	protected static FloorUpdate fromAPI(JSONObject json) throws JSONException, ParseException {

--- a/app/src/main/java/com/sunlightlabs/congress/services/HearingService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/HearingService.java
@@ -26,7 +26,7 @@ public class HearingService {
 		return hearingsFor(ProPublica.url(endpoint, page));
 	}
 	
-	private static Hearing fromJSON(JSONObject json) throws JSONException, ParseException, CongressException {
+	private static Hearing fromJSON(JSONObject json) throws JSONException, ParseException {
 		Hearing hearing = new Hearing();
 		
 		if (!json.isNull("description"))

--- a/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/LegislatorService.java
@@ -103,7 +103,7 @@ public class LegislatorService {
 	
 	/* JSON parsers, also useful for other service endpoints within this package */
 
-	protected static Legislator fromAPI(JSONObject json) throws ParseException, JSONException, CongressException {
+	protected static Legislator fromAPI(JSONObject json) throws ParseException, JSONException {
         if (json == null)
             return null;
 

--- a/app/src/main/java/com/sunlightlabs/congress/services/UpcomingBillService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/UpcomingBillService.java
@@ -20,7 +20,7 @@ public class UpcomingBillService {
         return upcomingBillsFor(ProPublica.url(house));
 	}
 	
-	protected static UpcomingBill fromAPI(JSONObject json) throws JSONException, ParseException, CongressException {
+	protected static UpcomingBill fromAPI(JSONObject json) throws JSONException, ParseException {
 		UpcomingBill upcoming = new UpcomingBill();
 
         if (!json.isNull("congress"))

--- a/app/src/main/java/lgpl/haustein/Base64Encoder.java
+++ b/app/src/main/java/lgpl/haustein/Base64Encoder.java
@@ -43,7 +43,7 @@ public final class Base64Encoder {
      * @return the input string encoded using Base 64 encoding.
      */
     public static String encode (String string) {
-        return encode(string.getBytes()).toString ();
+        return encode(string.getBytes());
     }
     
     public static String encode (byte [] data) {

--- a/app/src/main/java/lgpl/haustein/Base64Encoder.java
+++ b/app/src/main/java/lgpl/haustein/Base64Encoder.java
@@ -119,7 +119,7 @@ public final class Base64Encoder {
         case '/': return 63;
         case '=': return 0;
         default:
-            throw new RuntimeException (new StringBuffer("unexpected code: ").append(c).toString());
+            throw new RuntimeException ("unexpected code: " + c);
         }
     }
                 


### PR DESCRIPTION
- there were a few places where toString() was called on String objects
- the equals() method in the ViewHolder static class in LegislatorListFragments could generate ClassCastExceptions
- removed several spots where the code claimed CongressExceptions could be thrown but actually didn't
- used Java 5 style for loops with various collections instead of older style for and while loops
- removed public and static modifiers off of interfaces since they don't do anything
- removed some unnecessary casting and local variable creation for returns