### PR TITLE
Fixing breaking bugs on bill loading and dialing legislators

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
 
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.sunlightlabs.android.congress"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
     }
 
     buildTypes {
@@ -29,7 +29,7 @@ dependencies {
     implementation files('libs/jackson-core-2.3.1.jar')
     implementation files('libs/jackson-databind-2.3.1.jar')
 
-    implementation 'com.android.support:support-v13:26.1.0'
+    implementation 'com.android.support:support-v13:28.0.0'
     implementation 'com.squareup.okhttp:okhttp:1.3.0'
     implementation 'com.squareup.picasso:picasso:2.2.0'
     implementation 'com.google.android.gms:play-services:4.3.23'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
 
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.sunlightlabs.android.congress"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
     }
 
     buildTypes {
@@ -29,7 +29,7 @@ dependencies {
     implementation files('libs/jackson-core-2.3.1.jar')
     implementation files('libs/jackson-databind-2.3.1.jar')
 
-    implementation 'com.android.support:support-v13:25.3.1'
+    implementation 'com.android.support:support-v13:26.1.0'
     implementation 'com.squareup.okhttp:okhttp:1.3.0'
     implementation 'com.squareup.picasso:picasso:2.2.0'
     implementation 'com.google.android.gms:play-services:4.3.23'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation files('libs/jackson-core-2.3.1.jar')
     implementation files('libs/jackson-databind-2.3.1.jar')
 
-    implementation 'com.android.support:support-v13:28.0.0'
+    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'com.squareup.okhttp:okhttp:1.3.0'
     implementation 'com.squareup.picasso:picasso:2.2.0'
     implementation 'com.google.android.gms:play-services:4.3.23'

--- a/app/src/main/java/com/sunlightlabs/android/congress/LegislatorPager.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/LegislatorPager.java
@@ -200,12 +200,16 @@ public class LegislatorPager extends Activity implements HasActionMenu, LoadPhot
     public void callOffice() {
         Analytics.legislatorCall(this, legislator.bioguide_id);
 
+        Intent intent;
         // if user gave us permission to directly initiate calls, do so
         if (Utils.checkPermission(this, Manifest.permission.CALL_PHONE))
-            startActivity(new Intent(Intent.ACTION_CALL, Uri.parse("tel://" + legislator.phone)));
+            intent = new Intent(Intent.ACTION_CALL);
         // otherwise, open up the dialer with the number ready to go (needs no permission)
         else
-            startActivity(new Intent(Intent.ACTION_DIAL));
+            intent = new Intent(Intent.ACTION_DIAL);
+
+        intent.setData(Uri.parse("tel:" + legislator.phone));
+        startActivity(intent);
     }
 
     public void visit(String url, String social) {

--- a/app/src/main/java/com/sunlightlabs/android/congress/LegislatorPager.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/LegislatorPager.java
@@ -33,6 +33,8 @@ import com.sunlightlabs.android.congress.utils.Utils;
 import com.sunlightlabs.congress.models.CongressException;
 import com.sunlightlabs.congress.models.Legislator;
 
+import androidx.core.app.ActivityCompat;
+
 public class LegislatorPager extends Activity implements HasActionMenu, LoadPhotoTask.LoadsPhoto {
 	public String bioguide_id;
 	public Legislator legislator;
@@ -42,6 +44,8 @@ public class LegislatorPager extends Activity implements HasActionMenu, LoadPhot
 	
 	public Database database;
 	public Cursor cursor;
+
+	public static final int PERMISSION_TO_DIAL_DIRECTLY = 0;
 	
 	
 	@Override
@@ -200,16 +204,42 @@ public class LegislatorPager extends Activity implements HasActionMenu, LoadPhot
     public void callOffice() {
         Analytics.legislatorCall(this, legislator.bioguide_id);
 
-        Intent intent;
         // if user gave us permission to directly initiate calls, do so
         if (Utils.checkPermission(this, Manifest.permission.CALL_PHONE))
+            doCallOffice(true);
+        // otherwise, prompt for permission
+        else
+            ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.CALL_PHONE}, PERMISSION_TO_DIAL_DIRECTLY);
+
+    }
+
+    // Execute either a direct or an indirect dial.
+    public void doCallOffice(boolean direct) {
+	    Intent intent;
+        if (direct)
             intent = new Intent(Intent.ACTION_CALL);
-        // otherwise, open up the dialer with the number ready to go (needs no permission)
         else
             intent = new Intent(Intent.ACTION_DIAL);
 
-        intent.setData(Uri.parse("tel:" + legislator.phone));
+	    intent.setData(Uri.parse("tel:" + legislator.phone));
         startActivity(intent);
+	}
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+        switch (requestCode) {
+            case PERMISSION_TO_DIAL_DIRECTLY: {
+                // if we got permission, dial them
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED)
+                    doCallOffice(true);
+
+                // otherwise, fall back to opening the dialer with number ready to go (needs no permission)
+                else
+                    doCallOffice(false);
+
+                return;
+            }
+        }
     }
 
     public void visit(String url, String social) {

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/TitlePageAdapter.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/TitlePageAdapter.java
@@ -7,8 +7,8 @@ import java.util.Map;
 
 import android.app.Activity;
 import android.app.Fragment;
-import android.support.v13.app.FragmentPagerAdapter;
-import android.support.v4.view.ViewPager;
+import androidx.legacy.app.FragmentPagerAdapter;
+import androidx.viewpager.widget.ViewPager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
+++ b/app/src/main/java/com/sunlightlabs/android/congress/utils/Utils.java
@@ -1,13 +1,12 @@
 package com.sunlightlabs.android.congress.utils;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.preference.PreferenceManager;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TabHost;

--- a/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
+++ b/app/src/main/java/com/sunlightlabs/congress/services/BillService.java
@@ -68,7 +68,7 @@ public class BillService {
 	public static Bill find(String id) throws CongressException {
         String[] pieces = Bill.splitBillId(id);
         String typeNumber = pieces[0] + pieces[1];
-        String[] endpoint = { String.valueOf(Bill.currentCongress()), "bills", typeNumber };
+        String[] endpoint = { String.valueOf(pieces[2]), "bills", typeNumber };
 		return billFor(ProPublica.url(endpoint));
 	}
 

--- a/app/src/main/res/layout/pager.xml
+++ b/app/src/main/res/layout/pager.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         />
     
-	<android.support.v4.view.ViewPager
+	<androidx.viewpager.widget.ViewPager
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/congress-android.iml
+++ b/congress-android.iml
@@ -13,7 +13,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
This PR:

* Fixes loading bills in prior Congresses (which is most of them right now).
* Properly passes the phone number to the dialer when calling a legislator.
* Properly requests permission for, and then uses as appropriate, the direct dialing permission.
* Moves from the Android support library to AndroidX.
* Updates target SDK to be 28.